### PR TITLE
Implement GitHub class which retries abuse-limited queries

### DIFF
--- a/src/gql.ts
+++ b/src/gql.ts
@@ -1,0 +1,53 @@
+import {InMemoryCache, NormalizedCache} from 'apollo-cache-inmemory';
+import ApolloClient from 'apollo-client';
+import {ApolloQueryResult} from 'apollo-client/core/types';
+import {WatchQueryOptions} from 'apollo-client/core/watchQueryOptions';
+import {HttpLink} from 'apollo-link-http';
+import fetch from 'node-fetch';
+import {promisify} from 'util';
+
+class GitHub {
+  private apollo: ApolloClient<NormalizedCache>;
+
+  constructor() {
+    this.apollo = new ApolloClient({
+      link: new HttpLink({
+        uri: 'https://api.github.com/graphql',
+        headers: {
+          'Authorization': 'bearer ' + process.env.GITHUB_TOKEN,
+          'User-Agent': 'Project Health'
+        },
+        fetch: fetch,
+      }),
+      cache: new InMemoryCache(),
+    });
+  }
+
+  /**
+   * Wrapper for Apollo's query function that retries automatically.
+   */
+  async query<T>(options: WatchQueryOptions): Promise<ApolloQueryResult<T>> {
+    let result;
+    let retries = 0;
+    while (!result) {
+      try {
+        if (options.notifyOnNetworkStatusChange != undefined)
+          debugger;
+        result = await this.apollo.query<T>(Object.assign({}, options));
+      } catch (e) {
+        // Retry the request up to 5 times, backing off an extra second each
+        // time.
+        if (e.networkError && e.networkError.statusCode === 403 &&
+            retries < 5) {
+          await promisify(setTimeout)((retries + 1) * 1000);
+          retries++;
+        } else {
+          throw e;
+        }
+      }
+    }
+    return result;
+  }
+}
+
+export default new GitHub();

--- a/src/metrics/review-latency.ts
+++ b/src/metrics/review-latency.ts
@@ -14,24 +14,10 @@
  * the License.
  */
 
-import {InMemoryCache} from 'apollo-cache-inmemory';
-import ApolloClient from 'apollo-client';
-import {HttpLink} from 'apollo-link-http';
 import gql from 'graphql-tag';
-import fetch from 'node-fetch';
-import * as gqlTypes from '../gql-types';
 
-const github = new ApolloClient({
-  link: new HttpLink({
-    uri: 'https://api.github.com/graphql',
-    headers: {
-      'Authorization': 'bearer ' + process.env.GITHUB_TOKEN,
-      'User-Agent': 'Project Health'
-    },
-    fetch: fetch,
-  }),
-  cache: new InMemoryCache(),
-});
+import github from '../gql';
+import * as gqlTypes from '../gql-types';
 
 const orgReposQuery = gql`
   query OrgRepos($login: String!, $cursor: String) {


### PR DESCRIPTION
In some cases, GitHub queries may result in abuse-limits, where queries are deemed too computationally expensive to perform at that time. As they are not deterministic on our end, we need to handle and retry these failures accordingly.