### PR TITLE
Add a basic authentication layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules/
 /lib/
 /src/gql-types.ts
+/.nyc_output/

--- a/package.json
+++ b/package.json
@@ -26,33 +26,39 @@
   "homepage": "https://github.com/PolymerLabs/project-health#readme",
   "devDependencies": {
     "@types/fs-extra": "^4.0.5",
-    "@types/request": "^2.0.8",
     "apollo-codegen": "^0.17.2",
     "ava": "^0.23.0",
     "clang-format": "^1.1.1",
     "coveralls": "^3.0.0",
     "fs-extra": "^4.0.2",
     "nyc": "^11.4.0",
-    "request": "^2.83.0",
     "tslint": "^5.8.0",
     "typescript": "^2.6.2",
     "watchy": "^0.7.0"
   },
   "dependencies": {
     "@types/command-line-args": "^4.0.2",
+    "@types/cookie-parser": "^1.4.1",
     "@types/express": "^4.0.39",
     "@types/graphql": "^0.11.7",
     "@types/node": "^8.0.53",
     "@types/node-fetch": "^1.6.7",
+    "@types/request-promise-native": "^1.0.10",
     "apollo-cache-inmemory": "^1.1.2",
     "apollo-client": "^2.1.0",
+    "apollo-link-context": "^1.0.2",
     "apollo-link-http": "^1.3.0",
+    "body-parser": "^1.18.2",
     "command-line-args": "^4.0.7",
     "command-line-usage": "^4.0.1",
+    "cookie-parser": "^1.4.3",
     "express": "^4.16.2",
     "graphql-tag": "^2.5.0",
     "lit-html": "^0.7.1",
-    "node-fetch": "^1.7.3"
+    "node-fetch": "^1.7.3",
+    "request": "^2.83.0",
+    "@types/request": "^2.0.8",
+    "request-promise-native": "^1.0.5"
   },
   "nyc": {
     "exclude": [

--- a/src/server/static/dash.js
+++ b/src/server/static/dash.js
@@ -1,7 +1,7 @@
 import {html, render} from '/lit-html/lit-html.js'
 
 async function start() {
-  const res = await fetch('/dash.json');
+  const res = await fetch('/dash.json', {credentials: 'include'});
   const json = await res.json();
 
   const authorTemplate = (author) => html`
@@ -11,11 +11,11 @@ async function start() {
   // TODO: review requests can be less than totalCount.
   const reviewRequestsTemplate = (requests) => html`
     ${
-      requests.totalCount > 0 ? html
-          `waiting on ${
-              requests.nodes.map(
-                  (request) => authorTemplate(request.requestedReviewer))}` :
-                                ``}
+      requests.totalCount > 0 ?
+      html
+  `waiting on ${
+      requests.nodes.map(
+          (request) => authorTemplate(request.requestedReviewer))}`: ``}
   `;
 
   const reviewTemplate = (review) => html`

--- a/src/server/static/index.html
+++ b/src/server/static/index.html
@@ -1,0 +1,15 @@
+<script>
+  var queryParams = new URLSearchParams(window.location.search);
+
+  if (queryParams.has('code')) {
+    fetch('/login', {
+      method: 'POST',
+      body: queryParams.get('code'),
+      credentials: 'include',
+    }).then(() => {
+      window.location.href = '/dash.html';
+    });
+  } else {
+    window.location = 'https://github.com/login/oauth/authorize?client_id=23b7d82aec29a3a1a2a8';
+  }
+</script>


### PR DESCRIPTION
This adds `/` as the default endpoint. It will send you to GitHub to authorize this application, exchange for an access token and store the access token unencrypted as a cookie on the client. This token is then used for future requests for dashboard data.

In the future, the access token will not be sent to the client and instead stored as an encrypted token in a database.