### PR TITLE
Push model

### DIFF
--- a/client/push.ts
+++ b/client/push.ts
@@ -1,9 +1,5 @@
 import {html, render} from './node_modules/lit-html/lit-html.js';
 
-declare var PushManager: {
-  supportedContentEncodings?: string[];
-};
-
 const PUBLIC_VAPID_KEY = 'BOX5Lqb44uosZL4_UtV7XW9dHaBj9ERFbCzlsYZBObMZjIB-yxPIbjI5pTBgIt09iy-Hl57AWpr7lJ6QXaQjy30';
 
 async function updateBackend(isUnsubscribed: boolean, subscription: PushSubscription) {
@@ -12,7 +8,8 @@ async function updateBackend(isUnsubscribed: boolean, subscription: PushSubscrip
   } else {
     const bodyContent = {
       subscription: subscription.toJSON(),
-      supportedContentEncodings: PushManager.supportedContentEncodings || [],
+      supportedContentEncodings:
+        (PushManager as {supportedContentEncodings?: string[]}).supportedContentEncodings || [],
     };
 
     await fetch(`/api/push-subscription/add`, {

--- a/client/push.ts
+++ b/client/push.ts
@@ -1,5 +1,9 @@
 import {html, render} from './node_modules/lit-html/lit-html.js';
 
+declare var PushManager: {
+  supportedContentEncodings?: string[];
+};
+
 const PUBLIC_VAPID_KEY = 'BOX5Lqb44uosZL4_UtV7XW9dHaBj9ERFbCzlsYZBObMZjIB-yxPIbjI5pTBgIt09iy-Hl57AWpr7lJ6QXaQjy30';
 
 async function updateBackend(isUnsubscribed: boolean, subscription: PushSubscription) {
@@ -8,7 +12,7 @@ async function updateBackend(isUnsubscribed: boolean, subscription: PushSubscrip
   } else {
     const bodyContent = {
       subscription: subscription.toJSON(),
-      supportedContentEncodings: (PushManager as any).supportedContentEncodings || [],
+      supportedContentEncodings: PushManager.supportedContentEncodings || [],
     };
 
     await fetch(`/api/push-subscription/add`, {

--- a/client/push.ts
+++ b/client/push.ts
@@ -2,11 +2,23 @@ import {html, render} from './node_modules/lit-html/lit-html.js';
 
 const PUBLIC_VAPID_KEY = 'BOX5Lqb44uosZL4_UtV7XW9dHaBj9ERFbCzlsYZBObMZjIB-yxPIbjI5pTBgIt09iy-Hl57AWpr7lJ6QXaQjy30';
 
-function updateBackend(isUnsubscribed: boolean, subscription: PushSubscription) {
+async function updateBackend(isUnsubscribed: boolean, subscription: PushSubscription) {
   if (isUnsubscribed) {
     console.log('TODO: Must remove subscription from backend', subscription);
   } else {
-    console.log('TODO: Add subscription to backend', subscription);
+    const bodyContent = {
+      subscription: subscription.toJSON(),
+      supportedContentEncodings: (PushManager as any).supportedContentEncodings || [],
+    };
+
+    await fetch(`/api/push-subscription/add`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(bodyContent),
+    });
   }
 }
 
@@ -37,7 +49,7 @@ function urlBase64ToUint8Array(base64String: string) {
  */
 function getRegistration(): Promise<ServiceWorkerRegistration> {
   return navigator.serviceWorker.register('/push-sw.js', {
-    scope: '/build/__dash/push/',
+    scope: '/__dash/push/',
   });
 }
 
@@ -110,6 +122,12 @@ async function updateUI() {
 async function start() {
   if (!navigator.serviceWorker || !('PushManager' in window)) {
     return;
+  }
+
+  const registration = await getRegistration();
+  const subscription = await registration.pushManager.getSubscription();
+  if (subscription) {
+    await updateBackend(false, subscription);
   }
 
   updateUI();

--- a/server/src/dash-server.ts
+++ b/server/src/dash-server.ts
@@ -95,6 +95,7 @@ export class DashServer {
       return;
     }
 
+    // TODO: We shouldn't make this request for Github login repeatedly.
     const token = req.cookies['id'];
     const loginResult = await this.github.query<ViewerLoginQuery>(
         {query: viewerLoginQuery, context: {token}});

--- a/server/src/dash-server.ts
+++ b/server/src/dash-server.ts
@@ -8,6 +8,7 @@ import * as request from 'request-promise-native';
 
 import {DashResponse, PullRequest} from '../../api';
 
+import {PushSubscriptionModel} from './models/PushSubscriptionModel';
 import {GitHub} from './github';
 import {ViewerLoginQuery, ViewerPullRequestsQuery} from './gql-types';
 
@@ -18,6 +19,7 @@ export class DashServer {
   };
   private github: GitHub;
   private app: express.Express;
+  private pushSubscriptions: PushSubscriptionModel;
 
   constructor(github: GitHub, secrets: {
     GITHUB_CLIENT_ID: string,
@@ -25,6 +27,8 @@ export class DashServer {
   }) {
     this.github = github;
     this.secrets = secrets;
+    this.pushSubscriptions = new PushSubscriptionModel();
+
     const app = express();
     const litPath = path.join(__dirname, '../../client/node_modules/lit-html');
 
@@ -34,6 +38,7 @@ export class DashServer {
 
     app.get('/dash.json', this.handleDashJson.bind(this));
     app.post('/login', bodyParser.text(), this.handleLogin.bind(this));
+    app.post('/api/push-subscription/add', bodyParser.json(), this.addPushSubscription.bind(this));
 
     this.app = app;
   }
@@ -81,6 +86,27 @@ export class DashServer {
     }
 
     res.cookie('id', postResp['access_token'], {httpOnly: true});
+    res.end();
+  }
+
+  async addPushSubscription(req: express.Request, res: express.Response) {
+    const token = req.cookies['id'];
+    const loginResult = await this.github.query<ViewerLoginQuery>(
+        {query: viewerLoginQuery, context: {token}});
+    const login = loginResult.data.viewer.login;
+
+    if (!req.body) {
+      res.sendStatus(400);
+      return;
+    }
+
+    // console.log(this.pushSubscriptions.addPushSubscription());
+    this.pushSubscriptions.addPushSubscription(
+      login,
+      req.body.subscription,
+      req.body.supportedContentEncodings
+    );
+
     res.end();
   }
 

--- a/server/src/dash-server.ts
+++ b/server/src/dash-server.ts
@@ -90,17 +90,21 @@ export class DashServer {
   }
 
   async addPushSubscription(req: express.Request, res: express.Response) {
-    const token = req.cookies['id'];
-    const loginResult = await this.github.query<ViewerLoginQuery>(
-        {query: viewerLoginQuery, context: {token}});
-    const login = loginResult.data.viewer.login;
-
     if (!req.body) {
       res.sendStatus(400);
       return;
     }
 
-    // console.log(this.pushSubscriptions.addPushSubscription());
+    const token = req.cookies['id'];
+    const loginResult = await this.github.query<ViewerLoginQuery>(
+        {query: viewerLoginQuery, context: {token}});
+    const login = loginResult.data.viewer.login;
+
+    if (!login) {
+      res.sendStatus(400);
+      return;
+    }
+
     this.pushSubscriptions.addPushSubscription(
       login,
       req.body.subscription,

--- a/server/src/models/PushSubscriptionModel.ts
+++ b/server/src/models/PushSubscriptionModel.ts
@@ -13,7 +13,7 @@ class PubscriptionInfo {
 }
 
 class PushSubscriptionModel {
-  private pushSubscriptions: {[id: string]: PubscriptionInfo[]};
+  private pushSubscriptions: {[id: string]: Set<PubscriptionInfo>};
 
   constructor() {
     this.pushSubscriptions = {};
@@ -21,9 +21,9 @@ class PushSubscriptionModel {
 
   addPushSubscription(userId: string, subscription: PushSubscription, supportedContentEncodings: string[]) {
     if (!this.pushSubscriptions[userId]) {
-      this.pushSubscriptions[userId] = [];
+      this.pushSubscriptions[userId] = new Set();
     }
-    this.pushSubscriptions[userId].push({
+    this.pushSubscriptions[userId].add({
       subscription,
       supportedContentEncodings,
     });

--- a/server/src/models/PushSubscriptionModel.ts
+++ b/server/src/models/PushSubscriptionModel.ts
@@ -1,0 +1,33 @@
+class PushSubscription {
+  endpoint: string;
+  expirationTime: number | null;
+  keys: {
+    p256dh: string;
+    auth: string;
+  };
+}
+
+class PubscriptionInfo {
+  subscription: PushSubscription;
+  supportedContentEncodings: string[];
+}
+
+class PushSubscriptionModel {
+  private pushSubscriptions: {[id: string]: PubscriptionInfo[]};
+
+  constructor() {
+    this.pushSubscriptions = {};
+  }
+
+  addPushSubscription(userId: string, subscription: PushSubscription, supportedContentEncodings: string[]) {
+    if (!this.pushSubscriptions[userId]) {
+      this.pushSubscriptions[userId] = [];
+    }
+    this.pushSubscriptions[userId].push({
+      subscription,
+      supportedContentEncodings,
+    });
+  }
+}
+
+export { PushSubscriptionModel };

--- a/server/src/models/PushSubscriptionModel.ts
+++ b/server/src/models/PushSubscriptionModel.ts
@@ -7,13 +7,13 @@ class PushSubscription {
   };
 }
 
-class PubscriptionInfo {
+class PubSubscriptionInfo {
   subscription: PushSubscription;
   supportedContentEncodings: string[];
 }
 
-class PushSubscriptionModel {
-  private pushSubscriptions: {[id: string]: Set<PubscriptionInfo>};
+export class PushSubscriptionModel {
+  private pushSubscriptions: {[id: string]: Set<PubSubscriptionInfo>};
 
   constructor() {
     this.pushSubscriptions = {};
@@ -29,5 +29,3 @@ class PushSubscriptionModel {
     });
   }
 }
-
-export { PushSubscriptionModel };


### PR DESCRIPTION
Adds endpoint `/api/push-subscriptions/add` to accept push subscriptions and the corresponding supported content encoding from the client to the server.

Saves this to a model that will stash this in memory for now.