### PR TITLE
Simplify format command

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "install": "npm run npm-install",
     "deploy:gcloud": "gcloud app deploy app.yaml --project project-health-test",
     "deploy": "npm run build && npm run clean && npm run deploy:gcloud && npm run npm-install",
-    "format": "find server/src client -path client/node_modules -prune -o -name '*.ts' | xargs clang-format --style=file -i",
+    "format": "find server/src client/*.ts -name '*.ts' | xargs clang-format --style=file -i",
     "precommit": "npm run format",
     "server": "npm run build && node server.js"
   },


### PR DESCRIPTION
Currently it prints a random "is a directory" because `client/node_modules` shows up in that find command. This fixes that and simplifies it.