### PR TITLE
Prune server deps that aren't .js, .json, or .node files before deploy.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "clean:client": "cd ./client/ && rm -rf ./node_modules && npm install --only=production",
-    "clean:server": "cd ./server/ && rm -rf ./node_modules && npm install --only=production",
+    "clean:server": "cd ./server/ && rm -rf ./node_modules && npm install --only=production && cd node_modules && echo num dep files before prune: $(find . -type f | wc -l) && find . -type f -not \\( -name '*.js' -or -name '*.json' -or -name '*.node' \\) -delete && echo num dep files after prune: $(find . -type f | wc -l)",
     "clean": "npm run clean:client && npm run clean:server",
     "build:client": "cd ./client/ && npm run build",
     "build:server": "cd ./server/ && npm run build",


### PR DESCRIPTION
As of this commit, drops the number of files in server/node_modules from 3068 to 1987.

Once we add firestore, it drops from 10,858 to 3493.