### PR TITLE
Style: enforce single quote, avoid template strings where possible

### DIFF
--- a/src/cli/metric-cli.ts
+++ b/src/cli/metric-cli.ts
@@ -62,11 +62,11 @@ export async function run(argv: string[]) {
   if (args.help) {
     console.log(commandLineUsage([
       {
-        header: `[blue]{Project Health metrics}`,
+        header: '[blue]{Project Health metrics}',
         content: 'https://github.com/PolymerLabs/project-health',
       },
       {
-        header: `Options`,
+        header: 'Options',
         optionList: argDefs,
       }
     ]));

--- a/src/cli/transfer-cli.ts
+++ b/src/cli/transfer-cli.ts
@@ -144,11 +144,11 @@ export async function run(argv: string[]) {
   if (args.help) {
     console.log(commandLineUsage([
       {
-        header: `[blue]{Project Health transfer script}`,
+        header: '[blue]{Project Health transfer script}',
         content: 'https://github.com/PolymerLabs/project-health',
       },
       {
-        header: `Options`,
+        header: 'Options',
         optionList: argDefs,
       }
     ]));

--- a/src/client/push.ts
+++ b/src/client/push.ts
@@ -106,9 +106,9 @@ async function getNotificationButtonText() {
   const subscription = await registration.pushManager.getSubscription();
 
   if (subscription) {
-    return `Disable Notifications`;
+    return 'Disable Notifications';
   } else {
-    return `Enable Notifications`;
+    return 'Enable Notifications';
   }
 }
 

--- a/tslint.json
+++ b/tslint.json
@@ -44,6 +44,7 @@
     "object-literal-shorthand": true,
     "only-arrow-functions": [true, "allow-declarations", "allow-named-functions"],
     "prefer-const": true,
+    "quotemark": [true, "single", "avoid-template"],
     "radix": true,
     "semicolon": [true, "always", "ignore-bound-class-methods"],
     "switch-default": true,


### PR DESCRIPTION
For consistency, this is now enforced via a tslint rule.