### PR TITLE
Fix travis auto deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,4 @@ deploy:
   keyfile: github-health-staging-5ed56f9155c0-travis.json
   project: github-health-staging
   default: true
+  skip_cleanup: true # Required so build/ doesn't get cleaned.


### PR DESCRIPTION
By default, Travis performs a cleanup step (git clean) before deploying. It our case, we need all the built files to deploy.