### PR TITLE
Fixing the uncached user issue

### DIFF
--- a/src/server/apis/dash-data.ts
+++ b/src/server/apis/dash-data.ts
@@ -18,7 +18,7 @@ export class DashData {
   }
 
   private async handler(req: express.Request, res: express.Response) {
-    const loginDetails = await userModel.getLoginFromRequest(req);
+    const loginDetails = await userModel.getLoginFromRequest(this.github, req);
     if (!loginDetails) {
       res.sendStatus(401);
       return;

--- a/src/server/apis/push-subscription.ts
+++ b/src/server/apis/push-subscription.ts
@@ -1,10 +1,11 @@
 import * as bodyParser from 'body-parser';
 import * as express from 'express';
 
+import {GitHub} from '../../utils/github';
 import {getSubscriptionModel} from '../models/pushSubscriptionModel';
 import {userModel} from '../models/userModel';
 
-function getRouter(): express.Router {
+function getRouter(github: GitHub): express.Router {
   const pushSubscriptionRouter = express.Router();
   pushSubscriptionRouter.post(
       '/:action',
@@ -16,7 +17,8 @@ function getRouter(): express.Router {
             return;
           }
 
-          const loginDetails = await userModel.getLoginFromRequest(request);
+          const loginDetails =
+              await userModel.getLoginFromRequest(github, request);
           if (!loginDetails) {
             response.status(400).send('No login details.');
             return;

--- a/src/server/apis/settings.ts
+++ b/src/server/apis/settings.ts
@@ -13,13 +13,18 @@ function getRouter(github: GitHub): express.Router {
   settingsRouter.post(
       '/orgs.json',
       async (request: express.Request, response: express.Response) => {
-        const loginDetails = await userModel.getLoginFromRequest(request);
+        const loginDetails =
+            await userModel.getLoginFromRequest(github, request);
         if (!loginDetails) {
           response.sendStatus(400);
           return;
         }
 
         const scopes = loginDetails.scopes;
+        if (!scopes) {
+          return;
+        }
+
         if ((scopes.indexOf('admin:org_hook') === -1 ||
              scopes.indexOf('read:org') === -1)) {
           response.status(400).send('Missing required scope.');

--- a/src/server/apis/webhook.ts
+++ b/src/server/apis/webhook.ts
@@ -52,7 +52,8 @@ function getRouter(github: GitHub, secrets: DashSecrets): express.Router {
   webhookRouter.post(
       '/:action',
       async (request: express.Request, response: express.Response) => {
-        const loginDetails = await userModel.getLoginFromRequest(request);
+        const loginDetails =
+            await userModel.getLoginFromRequest(github, request);
         if (!loginDetails) {
           response.sendStatus(400);
           return;

--- a/src/server/dash-server.ts
+++ b/src/server/dash-server.ts
@@ -44,7 +44,7 @@ export class DashServer {
         bodyParser.text(),
         getLoginRouter(this.github, this.secrets));
 
-    app.use('/api/push-subscription/', getPushSubRouter());
+    app.use('/api/push-subscription/', getPushSubRouter(this.github));
     app.use(
         '/api/webhook/',
         bodyParser.json(),


### PR DESCRIPTION
When the user has a token but the server doesn't have the details cached, they have to re-login, this PR changes that so the existing token is used - although we do lose the scope details.