### PR TITLE
Moves secrets, github and firestore into an application singleton

### DIFF
--- a/src/cli/common.ts
+++ b/src/cli/common.ts
@@ -17,16 +17,16 @@
 import gql from 'graphql-tag';
 
 import {OrgReposQuery, OrgReposQueryVariables} from '../types/gql-types';
-import {GitHub} from '../utils/github';
+import {github} from '../utils/github';
 
 /**
  * Fetch the repos under the given GitHub organization.
  */
-export async function getOrgRepos(github: GitHub, orgName: string):
+export async function getOrgRepos(orgName: string):
     Promise<Array<{owner: string, name: string}>> {
   const ids = [];
 
-  const results = github.cursorQuery<OrgReposQuery, OrgReposQueryVariables>(
+  const results = github().cursorQuery<OrgReposQuery, OrgReposQueryVariables>(
       orgReposQuery,
       {login: orgName},
       (data) => data.organization && data.organization.repositories);

--- a/src/cli/metric-cli.ts
+++ b/src/cli/metric-cli.ts
@@ -17,7 +17,6 @@
 import * as commandLineArgs from 'command-line-args';
 import * as ora from 'ora';
 
-import {GitHub} from '../utils/github';
 import {getIssueCounts} from './metrics/issue-counts';
 import {getReviewCoverage} from './metrics/review-coverage';
 import {getReviewLatency} from './metrics/review-latency';
@@ -81,28 +80,25 @@ export async function run(argv: string[]) {
     throw new Error('No GitHub org specified');
   }
 
-  const github = new GitHub();
-
   const metricSpinner = ora(`Gathering '${args.metric}' metric data`).start();
 
   let metricResult;
   const orgInfo = {org: args.org, repo: args.repo};
   switch (args.metric) {
     case 'review-latency':
-      metricResult = await getReviewLatency(github, orgInfo);
+      metricResult = await getReviewLatency(orgInfo);
       break;
     case 'issue-counts':
-      metricResult = await getIssueCounts(github, orgInfo);
+      metricResult = await getIssueCounts(orgInfo);
       break;
     case 'review-coverage':
       const yearAgo = new Date();
       yearAgo.setFullYear(yearAgo.getFullYear() - 1);
       metricResult = await getReviewCoverage(
-          github,
           {org: args.org, repo: args.repo, since: yearAgo.toISOString()});
       break;
     case 'stars':
-      metricResult = await getStars(github, {org: args.org, repo: args.repo});
+      metricResult = await getStars({org: args.org, repo: args.repo});
       break;
     default:
       metricSpinner.fail('Metric not found.');

--- a/src/cli/metrics/issue-counts.ts
+++ b/src/cli/metrics/issue-counts.ts
@@ -17,7 +17,7 @@
 import gql from 'graphql-tag';
 
 import {IssuesQuery, IssuesQueryVariables} from '../../types/gql-types';
-import {GitHub} from '../../utils/github';
+import {github} from '../../utils/github';
 import {getOrgRepos} from '../common';
 
 import {MetricResult} from './metric-result';
@@ -33,18 +33,18 @@ export type IssueCountOpts = {
  * Provides a time series containing the number of opened and closed issues for
  * each day.
  */
-export async function getIssueCounts(
-    github: GitHub, opts: IssueCountOpts): Promise<IssueCountResult> {
+export async function getIssueCounts(opts: IssueCountOpts):
+    Promise<IssueCountResult> {
   let repos;
   if (opts.repo) {
     repos = [{owner: opts.org, name: opts.repo}];
   } else {
-    repos = await getOrgRepos(github, opts.org);
+    repos = await getOrgRepos(opts.org);
   }
 
   const issues: Issue[] = [];
   for (const {owner, name} of repos) {
-    for (const issue of await getIssues(github, owner, name)) {
+    for (const issue of await getIssues(owner, name)) {
       issues.push(issue);
     }
   }
@@ -143,11 +143,10 @@ type Issue = {
 /**
  * Fetch all of the issues for a given repo.
  */
-async function getIssues(
-    github: GitHub, owner: string, name: string): Promise<Issue[]> {
+async function getIssues(owner: string, name: string): Promise<Issue[]> {
   const issues: Issue[] = [];
 
-  const results = github.cursorQuery<IssuesQuery, IssuesQueryVariables>(
+  const results = github().cursorQuery<IssuesQuery, IssuesQueryVariables>(
       issuesQuery,
       {owner, name},
       (data) => data.repository && data.repository.issues);

--- a/src/cli/metrics/stars.ts
+++ b/src/cli/metrics/stars.ts
@@ -17,7 +17,7 @@
 import gql from 'graphql-tag';
 
 import {StarsQuery, StarsQueryVariables} from '../../types/gql-types';
-import {GitHub} from '../../utils/github';
+import {github} from '../../utils/github';
 import {getOrgRepos} from '../common';
 
 import {MetricResult} from './metric-result';
@@ -51,19 +51,18 @@ type Star = {
 /**
  * Get all the stars for specified org/repo.
  */
-export async function getStars(
-    github: GitHub, opts: StarsOpts): Promise<StarsResult> {
+export async function getStars(opts: StarsOpts): Promise<StarsResult> {
   let repos;
   if (opts.repo) {
     repos = [{owner: opts.org, name: opts.repo}];
   } else {
-    repos = await getOrgRepos(github, opts.org);
+    repos = await getOrgRepos(opts.org);
   }
 
   const fetches = [];
 
   for (const {owner, name} of repos) {
-    fetches.push(fetchStarsForRepo(github, owner, name));
+    fetches.push(fetchStarsForRepo(owner, name));
   }
 
   const allStars = [];
@@ -93,11 +92,10 @@ const starsQuery = gql`
 /**
  * Fetches all starring events for a repo.
  */
-async function fetchStarsForRepo(
-    github: GitHub, owner: string, name: string): Promise<Star[]> {
+async function fetchStarsForRepo(owner: string, name: string): Promise<Star[]> {
   const stars: Star[] = [];
 
-  const results = github.cursorQuery<StarsQuery, StarsQueryVariables>(
+  const results = github().cursorQuery<StarsQuery, StarsQueryVariables>(
       starsQuery,
       {owner, name},
       (data) => data.repository && data.repository.stargazers);

--- a/src/replay-server.ts
+++ b/src/replay-server.ts
@@ -5,8 +5,6 @@ import * as http from 'http';
 import * as path from 'path';
 import * as request from 'request';
 
-import {GitHub} from './utils/github';
-
 const replayRoot = path.join(__dirname, '..', 'replays');
 const githubApiUrl = 'https://api.github.com/graphql';
 const githubJsonUrl = 'https://api.github.com';
@@ -26,7 +24,7 @@ let recordingLogged = false;
  * read back from those files.
  */
 export async function startTestReplayServer(t: ava.TestContext):
-    Promise<{server: http.Server, client: GitHub}> {
+    Promise<{server: http.Server, url: string}> {
   const record = process.env.RECORD === 'true';
 
   // Kind of weirdly, t.title will include the name of the current function
@@ -137,13 +135,13 @@ export async function startTestReplayServer(t: ava.TestContext):
     }
   }
 
-  return new Promise<{server: http.Server, client: GitHub}>((resolve) => {
+  return new Promise<{server: http.Server, url: string}>((resolve) => {
     const server = http.createServer(router);
     server.listen(/* random */ 0, '127.0.0.1', () => {
       const {address, port} = server.address();
       const url = `http://${address}:${port}`;
-      const client = new GitHub(url, url);
-      resolve({server, client});
+
+      resolve({server, url});
     });
   });
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,29 +18,19 @@ import * as fse from 'fs-extra';
 import * as path from 'path';
 
 import {DashServer} from './server/dash-server';
-import {GitHub} from './utils/github';
+import {initFirestore} from './utils/firestore';
+import {initGithub} from './utils/github';
+import {initSecrets} from './utils/secrets';
 
 const projectRoot = path.join(__dirname, '..');
 
 async function launch() {
   const secrets = await fse.readJSON(path.join(projectRoot, 'secrets.json'));
+  initSecrets(secrets);
+  initGithub();
+  initFirestore();
 
-  // See https://cloud.google.com/docs/authentication/production
-  for (const file of await fse.readdir(projectRoot)) {
-    if (file.match(/^github-health-.*\.json$/)) {
-      console.log('using gcloud credentials file', file);
-      process.env.GOOGLE_APPLICATION_CREDENTIALS = path.join(projectRoot, file);
-      break;
-    }
-  }
-
-  if (!process.env.GOOGLE_APPLICATION_CREDENTIALS) {
-    console.log(
-        'no gcloud credentials file found;',
-        'using application default credentials');
-  }
-
-  const server = new DashServer(new GitHub(), secrets);
+  const server = new DashServer();
   server.listen();
 }
 

--- a/src/server/apis/dash-data.ts
+++ b/src/server/apis/dash-data.ts
@@ -3,22 +3,16 @@ import gql from 'graphql-tag';
 
 import * as api from '../../types/api';
 import {mentionedFieldsFragment, prFieldsFragment, PullRequestReviewState, reviewFieldsFragment, ViewerPullRequestsQuery} from '../../types/gql-types';
-import {GitHub} from '../../utils/github';
+import {github} from '../../utils/github';
 import {userModel} from '../models/userModel';
 
 export class DashData {
-  private github: GitHub;
-
-  constructor(github: GitHub) {
-    this.github = github;
-  }
-
   getHandler() {
     return this.handler.bind(this);
   }
 
   private async handler(req: express.Request, res: express.Response) {
-    const loginDetails = await userModel.getLoginFromRequest(this.github, req);
+    const loginDetails = await userModel.getLoginFromRequest(req);
     if (!loginDetails) {
       res.sendStatus(401);
       return;
@@ -38,7 +32,7 @@ export class DashData {
         `review-requested:${login} ${openPrQuery}`;
     const mentionsQueryString = `${reviewedQueryString} mentions:${login}`;
 
-    const viewerPrsResult = await this.github.query<ViewerPullRequestsQuery>({
+    const viewerPrsResult = await github().query<ViewerPullRequestsQuery>({
       query: prsQuery,
       variables: {
         login,

--- a/src/server/apis/login.ts
+++ b/src/server/apis/login.ts
@@ -1,11 +1,10 @@
 import * as express from 'express';
 import fetch from 'node-fetch';
 
-import {GitHub} from '../../utils/github';
-import {DashSecrets} from '../dash-server';
+import {secrets} from '../../utils/secrets';
 import {userModel} from '../models/userModel';
 
-function getRouter(github: GitHub, secrets: DashSecrets): express.Router {
+function getRouter(): express.Router {
   const loginRouter = express.Router();
   loginRouter.post(
       '/', async (request: express.Request, response: express.Response) => {
@@ -22,8 +21,8 @@ function getRouter(github: GitHub, secrets: DashSecrets): express.Router {
                 'Content-Type': 'application/json',
               },
               body: JSON.stringify({
-                'client_id': secrets.GITHUB_CLIENT_ID,
-                'client_secret': secrets.GITHUB_CLIENT_SECRET,
+                'client_id': secrets().GITHUB_CLIENT_ID,
+                'client_secret': secrets().GITHUB_CLIENT_SECRET,
                 'code': request.body,
               }),
             });
@@ -39,7 +38,7 @@ function getRouter(github: GitHub, secrets: DashSecrets): express.Router {
         const userScopes = loginResponseBody['scope'] ?
             loginResponseBody['scope'].split(',') :
             [];
-        await userModel.addNewUser(github, accessToken, userScopes);
+        await userModel.addNewUser(accessToken, userScopes);
 
         response.cookie('id', accessToken, {httpOnly: true});
         response.end();

--- a/src/server/apis/push-subscription.ts
+++ b/src/server/apis/push-subscription.ts
@@ -1,11 +1,10 @@
 import * as bodyParser from 'body-parser';
 import * as express from 'express';
 
-import {GitHub} from '../../utils/github';
 import {getSubscriptionModel} from '../models/pushSubscriptionModel';
 import {userModel} from '../models/userModel';
 
-function getRouter(github: GitHub): express.Router {
+function getRouter(): express.Router {
   const pushSubscriptionRouter = express.Router();
   pushSubscriptionRouter.post(
       '/:action',
@@ -18,7 +17,7 @@ function getRouter(github: GitHub): express.Router {
           }
 
           const loginDetails =
-              await userModel.getLoginFromRequest(github, request);
+              await userModel.getLoginFromRequest(request);
           if (!loginDetails) {
             response.status(400).send('No login details.');
             return;

--- a/src/server/apis/settings.ts
+++ b/src/server/apis/settings.ts
@@ -3,18 +3,18 @@ import gql from 'graphql-tag';
 
 import {OrgWebHookState} from '../../types/api';
 import {OrgDetailsQuery} from '../../types/gql-types';
-import {GitHub} from '../../utils/github';
+import {github} from '../../utils/github';
 import {userModel} from '../models/userModel';
 
 import {WEBHOOK_URL} from './webhook';
 
-function getRouter(github: GitHub): express.Router {
+function getRouter(): express.Router {
   const settingsRouter = express.Router();
   settingsRouter.post(
       '/orgs.json',
       async (request: express.Request, response: express.Response) => {
         const loginDetails =
-            await userModel.getLoginFromRequest(github, request);
+            await userModel.getLoginFromRequest(request);
         if (!loginDetails) {
           response.sendStatus(400);
           return;
@@ -29,7 +29,7 @@ function getRouter(github: GitHub): express.Router {
         }
 
         try {
-          const orgDetails = await github.query<OrgDetailsQuery>({
+          const orgDetails = await github().query<OrgDetailsQuery>({
             query: orgsDetailsQuery,
             fetchPolicy: 'network-only',
             context: {
@@ -51,7 +51,7 @@ function getRouter(github: GitHub): express.Router {
 
               let hookEnabled = false;
               if (org.viewerCanAdminister) {
-                const hooks = await github.get(
+                const hooks = await github().get(
                     `orgs/${org.login}/hooks`, loginDetails.token);
 
                 for (const hook of hooks) {

--- a/src/server/controllers/notifications.ts
+++ b/src/server/controllers/notifications.ts
@@ -1,19 +1,19 @@
 import * as webpush from 'web-push';
 
 import {NotificationPayload} from '../../types/api';
-import {DashSecrets} from '../dash-server';
+import {secrets} from '../../utils/secrets';
 import {getSubscriptionModel} from '../models/pushSubscriptionModel';
 
-export const sendNotification = async (
-    secrets: DashSecrets, recipient: string, data: NotificationPayload) => {
+export const sendNotification =
+    async (recipient: string, data: NotificationPayload) => {
   const pushSubscriptionModel = getSubscriptionModel();
   const userSubscriptionDetails =
       await pushSubscriptionModel.getSubscriptionsForUser(recipient);
 
   webpush.setVapidDetails(
       'https://github-health.appspot.com',
-      secrets.PUBLIC_VAPID_KEY,
-      secrets.PRIVATE_VAPID_KEY,
+      secrets().PUBLIC_VAPID_KEY,
+      secrets().PRIVATE_VAPID_KEY,
   );
 
   return Promise.all(userSubscriptionDetails.map((subDetails) => {

--- a/src/server/controllers/webhook-events.ts
+++ b/src/server/controllers/webhook-events.ts
@@ -1,5 +1,4 @@
-import {sendNotification} from './controllers/notifications';
-import {DashSecrets} from './dash-server';
+import {sendNotification} from '../controllers/notifications';
 
 type UserHook = {
   login: string;
@@ -31,8 +30,7 @@ export async function handleStatus(_hookBody: string) {
 export async function handlePullRequest(_hookBody: {}) {
 }
 
-export async function handlePullRequestReview(
-    secrets: DashSecrets, hookData: PullRequestReviewHook) {
+export async function handlePullRequestReview(hookData: PullRequestReviewHook) {
   if (hookData.action === 'submitted') {
     const review = hookData.review;
     const repo = hookData.repository;
@@ -59,7 +57,7 @@ export async function handlePullRequestReview(
 
     if (notification) {
       const notificationRecipient = pullReq.user.login;
-      sendNotification(secrets, notificationRecipient, notification);
+      sendNotification(notificationRecipient, notification);
     }
   } else {
     throw new Error(

--- a/src/server/models/pushSubscriptionModel.ts
+++ b/src/server/models/pushSubscriptionModel.ts
@@ -1,4 +1,4 @@
-import {Firestore} from '@google-cloud/firestore';
+import {firestore} from '../../utils/firestore';
 
 interface PushSubscription {
   endpoint: string;
@@ -25,20 +25,15 @@ interface PushSubscriptionInfo {
  * since firebase keys cannot contain slashes.
  */
 class PushSubscriptionModel {
-  private firestore: Firestore;
-
-  constructor() {
-    this.firestore = new Firestore();
-  }
-
   private getSubscriptionCollection(login: string) {
-    return this.firestore.collection('users').doc(login).collection(
+    return firestore().collection('users').doc(login).collection(
         'subscriptions');
   }
 
   private getSubscriptionDoc(login: string, subscription: PushSubscription) {
     const b64Endpoint = new Buffer(subscription.endpoint).toString('base64');
-    return this.firestore.collection('users')
+    return firestore()
+        .collection('users')
         .doc(login)
         .collection('subscriptions')
         .doc(b64Endpoint);

--- a/src/server/models/userModel.ts
+++ b/src/server/models/userModel.ts
@@ -2,7 +2,7 @@ import * as express from 'express';
 import gql from 'graphql-tag';
 
 import {ViewerLoginQuery} from '../../types/gql-types';
-import {GitHub} from '../../utils/github';
+import {github} from '../../utils/github';
 
 interface LoginDetails {
   username: string;
@@ -18,7 +18,7 @@ class UserModel {
     this.cachedLogins = {};
   }
 
-  async getLoginFromRequest(github: GitHub, request: express.Request):
+  async getLoginFromRequest(request: express.Request):
       Promise<LoginDetails|null> {
     if (!request.cookies) {
       return null;
@@ -34,15 +34,15 @@ class UserModel {
     }
 
     try {
-      return await this.addNewUser(github, token, null);
+      return await this.addNewUser(token, null);
     } catch (err) {
       // If adding the user errors, then the token is no longer valid.
       return null;
     }
   }
 
-  async addNewUser(github: GitHub, token: string, scopes: string[]|null) {
-    const loginResult = await github.query<ViewerLoginQuery>({
+  async addNewUser(token: string, scopes: string[]|null) {
+    const loginResult = await github().query<ViewerLoginQuery>({
       query: viewerLoginQuery,
       fetchPolicy: 'network-only',
       context: {token},

--- a/src/test/cli/metrics/issue-count-test.ts
+++ b/src/test/cli/metrics/issue-count-test.ts
@@ -2,19 +2,21 @@ import test from 'ava';
 
 import {getIssueCounts} from '../../../cli/metrics/issue-counts';
 import {startTestReplayServer} from '../../../replay-server';
+import {initGithub} from '../../../utils/github';
 
 test.beforeEach(async (t) => {
-  const {server, client} = await startTestReplayServer(t);
+  const {server, url} = await startTestReplayServer(t);
   t.context.server = server;
-  t.context.client = client;
+
+  initGithub(url, url);
 });
 
 test.afterEach.cb((t) => {
   t.context.server.close(t.end);
 });
 
-test('WebComponents issue count', async (t) => {
-  const result = await getIssueCounts(t.context.client, {org: 'WebComponents'});
+test.serial('WebComponents issue count', async (t) => {
+  const result = await getIssueCounts({org: 'WebComponents'});
   t.is(result.issues.length, 1599);
   t.truthy(result.summary());
   t.truthy(result.rawData());

--- a/src/test/cli/metrics/review-coverage-test.ts
+++ b/src/test/cli/metrics/review-coverage-test.ts
@@ -2,26 +2,28 @@ import test from 'ava';
 
 import {getReviewCoverage} from '../../../cli/metrics/review-coverage';
 import {startTestReplayServer} from '../../../replay-server';
+import {initGithub} from '../../../utils/github';
 
 test.beforeEach(async (t) => {
-  const {server, client} = await startTestReplayServer(t);
+  const {server, url} = await startTestReplayServer(t);
   t.context.server = server;
-  t.context.client = client;
+
+  initGithub(url, url);
 });
 
 test.afterEach.cb((t) => {
   t.context.server.close(t.end);
 });
 
-test('gen-typescript-declarations review coverage', async (t) => {
+test.serial('gen-typescript-declarations review coverage', async (t) => {
   const result = await getReviewCoverage(
-      t.context.client, {org: 'polymer', repo: 'gen-typescript-declarations'});
+      {org: 'polymer', repo: 'gen-typescript-declarations'});
   t.is(result.numReviewed(), 79);
   t.is(result.commits.length, 82);
 });
 
-test('webcomponents.org review coverage', async (t) => {
-  const result = await getReviewCoverage(t.context.client, {
+test.serial('webcomponents.org review coverage', async (t) => {
+  const result = await getReviewCoverage({
     org: 'webcomponents',
     repo: 'webcomponents.org',
   });

--- a/src/test/cli/metrics/review-latency-test.ts
+++ b/src/test/cli/metrics/review-latency-test.ts
@@ -2,27 +2,28 @@ import test from 'ava';
 
 import {getReviewLatency} from '../../../cli/metrics/review-latency';
 import {startTestReplayServer} from '../../../replay-server';
+import {initGithub} from '../../../utils/github';
 
 test.beforeEach(async (t) => {
-  const {server, client} = await startTestReplayServer(t);
+  const {server, url} = await startTestReplayServer(t);
   t.context.server = server;
-  t.context.client = client;
+
+  initGithub(url, url);
 });
 
 test.afterEach.cb((t) => {
   t.context.server.close(t.end);
 });
 
-test('WebComponents review latency', async (t) => {
-  const result =
-      await getReviewLatency(t.context.client, {org: 'WebComponents'});
+test.serial('WebComponents review latency', async (t) => {
+  const result = await getReviewLatency({org: 'WebComponents'});
   t.is(result.totalLatency, 262575635000);
   t.is(result.reviews.length, 684);
 });
 
-test('WebComponents/webcomponents.org review latency', async (t) => {
-  const result = await getReviewLatency(
-      t.context.client, {org: 'WebComponents', repo: 'webcomponents.org'});
+test.serial('WebComponents/webcomponents.org review latency', async (t) => {
+  const result =
+      await getReviewLatency({org: 'WebComponents', repo: 'webcomponents.org'});
   t.is(result.totalLatency, 19466495000);
   t.is(result.reviews.length, 425);
   t.truthy(result.summary());

--- a/src/test/cli/metrics/stars-test.ts
+++ b/src/test/cli/metrics/stars-test.ts
@@ -2,25 +2,27 @@ import test from 'ava';
 
 import {getStars} from '../../../cli/metrics/stars';
 import {startTestReplayServer} from '../../../replay-server';
+import {initGithub} from '../../../utils/github';
 
 test.beforeEach(async (t) => {
-  const {server, client} = await startTestReplayServer(t);
+  const {server, url} = await startTestReplayServer(t);
   t.context.server = server;
-  t.context.client = client;
+
+  initGithub(url, url);
 });
 
 test.afterEach.cb((t) => {
   t.context.server.close(t.end);
 });
 
-test('WebComponents stars', async (t) => {
-  const result = await getStars(t.context.client, {org: 'WebComponents'});
+test.serial('WebComponents stars', async (t) => {
+  const result = await getStars({org: 'WebComponents'});
   t.is(result.stars.length, 6144);
 });
 
-test('WebComponents/webcomponents.org stars', async (t) => {
-  const result = await getStars(
-      t.context.client, {org: 'WebComponents', repo: 'webcomponents.org'});
+test.serial('WebComponents/webcomponents.org stars', async (t) => {
+  const result =
+      await getStars({org: 'WebComponents', repo: 'webcomponents.org'});
   t.is(result.stars.length, 127);
   t.truthy(result.summary());
   t.truthy(result.rawData());

--- a/src/test/server/apis/dash-data-test.ts
+++ b/src/test/server/apis/dash-data-test.ts
@@ -3,6 +3,7 @@ import * as ava from 'ava';
 import {startTestReplayServer} from '../../../replay-server';
 import {DashData} from '../../../server/apis/dash-data';
 import {PullRequestReviewState} from '../../../types/gql-types';
+import {initGithub} from '../../../utils/github';
 
 /**
  * Assigns the test context object before each test to ensure it is correctly
@@ -20,11 +21,12 @@ function contextualize<T>(getContext: (_: ava.TestContext) => Promise<T>):
  * Generates the test context object before each test.
  */
 const test = contextualize(async (t) => {
-  const {server, client} = await startTestReplayServer(t);
+  const {server, url} = await startTestReplayServer(t);
+  initGithub(url, url);
+  
   return {
     replayServer: server,
-    client,
-    dashData: new DashData(client),
+    dashData: new DashData(),
     // This token must be set in the environment during recording.
     token: process.env.GITHUB_TOKEN || '',
   };

--- a/src/test/server/models/PushSubscriptionModel-test.ts
+++ b/src/test/server/models/PushSubscriptionModel-test.ts
@@ -1,8 +1,7 @@
 import test from 'ava';
-import * as fse from 'fs-extra';
-import * as path from 'path';
 
 import {getSubscriptionModel} from '../../../server/models/pushSubscriptionModel';
+import {initFirestore} from '../../../utils/firestore';
 
 const USER_LOGIN = 'tests';
 const PUSH_SUBSCRIPTION = {
@@ -24,16 +23,7 @@ const PUSH_SUBSCRIPTION_2 = {
 const CONTENT_ENCODINGS = ['aes128gcm', 'aesgcm'];
 
 test.before(() => {
-  // See https://cloud.google.com/docs/authentication/production
-  if (!process.env.GOOGLE_APPLICATION_CREDENTIALS) {
-    const rootDir = path.join(__dirname, '..', '..', '..', '..');
-    for (const file of fse.readdirSync(rootDir)) {
-      if (file.match(/^github-health-.*\.json$/)) {
-        process.env.GOOGLE_APPLICATION_CREDENTIALS = path.join(rootDir, file);
-        break;
-      }
-    }
-  }
+  initFirestore();
 });
 
 test.beforeEach(async () => {

--- a/src/test/server/util/my-repos-test.ts
+++ b/src/test/server/util/my-repos-test.ts
@@ -2,6 +2,7 @@ import * as ava from 'ava';
 
 import {startTestReplayServer} from '../../../replay-server';
 import {getMyRepos} from '../../../server/utils/my-repos';
+import {initGithub} from '../../../utils/github';
 
 /**
  * Assigns the test context object before each test to ensure it is correctly
@@ -19,26 +20,21 @@ function contextualize<T>(getContext: (_: ava.TestContext) => Promise<T>):
  * Generates the test context object before each test.
  */
 const test = contextualize(async (t) => {
-  const {server, client} = await startTestReplayServer(t);
+  const {server, url} = await startTestReplayServer(t);
+
+  initGithub(url, url);
+  
   return {
-    server,
-    client,
+    replayServer: server,
   };
 });
 
-
-test.beforeEach(async (t) => {
-  const {server, client} = await startTestReplayServer(t);
-  t.context.server = server;
-  t.context.client = client;
-});
-
 test.afterEach.cb((t) => {
-  t.context.server.close(t.end);
+  t.context.replayServer.close(t.end);
 });
 
-test('top contributed repos for samuelli', async (t) => {
-  const result = await getMyRepos(t.context.client, 'samuelli', '');
+test.serial('top contributed repos for samuelli', async (t) => {
+  const result = await getMyRepos('samuelli', '');
   t.deepEqual(result, [
     'webcomponents/webcomponents.org',
     'GoogleChrome/rendertron',

--- a/src/utils/firestore.ts
+++ b/src/utils/firestore.ts
@@ -1,0 +1,41 @@
+import {Firestore} from '@google-cloud/firestore';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+
+let firestoreSingleton: Firestore|null = null;
+
+export function firestore(): Firestore {
+  if (!firestoreSingleton) {
+    throw new Error('Firestore is not initialised.');
+  }
+  return firestoreSingleton;
+}
+
+export function initFirestore() {
+  if (firestoreSingleton) {
+    throw new Error('Firestore is already initialised.');
+  }
+
+  if (process.env.NODE_ENV !== 'production') {
+    // See https://cloud.google.com/docs/authentication/production
+    let firestoreKeyFile;
+    const projectRoot = path.join(__dirname, '..', '..');
+    for (const file of fs.readdirSync(projectRoot)) {
+      if (file.match(/^github-health-.*\.json$/)) {
+        firestoreKeyFile = path.join(projectRoot, file);
+        break;
+      }
+    }
+
+    if (!firestoreKeyFile) {
+      throw new Error('Tests can only run with a staging key for Firestore.');
+    }
+
+    firestoreSingleton = new Firestore({
+      keyFile: firestoreKeyFile,
+    });
+  } else {
+    // AppEngine has env variables that configure Firestore
+    firestoreSingleton = new Firestore();
+  }
+}

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -19,13 +19,11 @@ const schema = require('../types/github-schema.json');
 (Symbol as any).asyncIterator =
     Symbol.asyncIterator || Symbol.for('Symbol.asyncIterator');
 
-export class GitHub {
+class GitHub {
   private apollo: ApolloClient<NormalizedCacheObject>;
   private jsonUrl: string;
 
-  constructor(
-      gqlUrl = 'https://api.github.com/graphql',
-      jsonUrl = 'https://api.github.com') {
+  constructor(gqlUrl: string, jsonUrl: string) {
     // Providing this fragment matcher initialized with the GitHub schema
     // allows the Apollo client to better distinguish polymorphic result types
     // by their "__type" field, which is required for certain queries.
@@ -181,3 +179,18 @@ export class GitHub {
 type PageInfo = {
   hasNextPage: boolean; endCursor: string | null;
 };
+
+let githubSingleton: GitHub|null = null;
+
+export function github(): GitHub {
+  if (!githubSingleton) {
+    throw new Error('Github is not initialised.');
+  }
+  return githubSingleton;
+}
+
+export function initGithub(
+    gqlUrl = 'https://api.github.com/graphql',
+    jsonUrl = 'https://api.github.com') {
+  githubSingleton = new GitHub(gqlUrl, jsonUrl);
+}

--- a/src/utils/secrets.ts
+++ b/src/utils/secrets.ts
@@ -1,0 +1,21 @@
+export type ApplicationSecrets = {
+  GITHUB_CLIENT_ID: string; GITHUB_CLIENT_SECRET: string;
+  PUBLIC_VAPID_KEY: string;
+  PRIVATE_VAPID_KEY: string;
+};
+
+let secretsSingleton: ApplicationSecrets|null = null;
+
+export function secrets(): ApplicationSecrets {
+  if (!secretsSingleton) {
+    throw new Error('Secrets are not initialised.');
+  }
+  return secretsSingleton;
+}
+
+export function initSecrets(secrets: ApplicationSecrets) {
+  if (secretsSingleton) {
+    throw new Error('Secrets already initialised.');
+  }
+  secretsSingleton = secrets;
+}


### PR DESCRIPTION
I'm not 100% convinced this is the neatest way to manage these values since everything is null by default, and getters are used at runtime to ensure the values have been set. The advantage is tests can set what is needed in terms of dependencies and leave everything else as null.