### PR TITLE
Moving user tokens into firestore

### DIFF
--- a/replays/Webhook-status:-error-travis.json/StatusToPR-13424304ef9ede31c5457b0561424cb81c52f552
+++ b/replays/Webhook-status:-error-travis.json/StatusToPR-13424304ef9ede31c5457b0561424cb81c52f552
@@ -1,0 +1,8 @@
+{
+  "data": {
+    "pullRequests": {
+      "nodes": [],
+      "__typename": "SearchResultItemConnection"
+    }
+  }
+}

--- a/src/client/settings/push-component.ts
+++ b/src/client/settings/push-component.ts
@@ -1,5 +1,5 @@
-import {addSubscriptionToBackend, removeSubscriptionFromBackend} from './push-backend.js';
 import {applicationServerKey} from './application-server-key.js';
+import {addSubscriptionToBackend, removeSubscriptionFromBackend} from './push-backend.js';
 
 interface PushComponentState {
   isSupported: boolean;
@@ -12,7 +12,7 @@ class PushComponent {
   private pushToggle: HTMLInputElement;
   private pushStatus: Element;
   private state: PushComponentState;
-  
+
   constructor() {
     const toggleElement =
       document.querySelector('.js-push-component__toggle') as HTMLInputElement;
@@ -37,7 +37,7 @@ class PushComponent {
     this.pushToggle.addEventListener('change', async (event) => {
       event.preventDefault();
       this.pushToggle.setAttribute('disabled', 'true');
-      
+
       if (this.pushToggle.checked) {
         await this.setupPush();
       } else {
@@ -53,7 +53,7 @@ class PushComponent {
         this.updatePermissionState(),
         this.updateSubscriptionState(),
       ]);
-  
+
       if (!this.state.isSupported) {
         this.pushStatus.textContent = '[Not Supported]';
         this.pushToggle.setAttribute('disabled', 'true');
@@ -62,7 +62,8 @@ class PushComponent {
         this.pushToggle.setAttribute('disabled', 'true');
       } else {
         this.pushToggle.removeAttribute('disabled');
-        this.pushToggle.checked = !!(this.state.subscription && this.state.savedToBackend);
+        this.pushToggle.checked =
+            !!(this.state.subscription && this.state.savedToBackend);
       }
 
     } catch (err) {
@@ -72,8 +73,9 @@ class PushComponent {
   }
 
   async updatePermissionState() {
-    // tslint:disable-next-line:no-any
-    const permissionState = await (navigator as any).permissions.query({name: 'notifications'});
+    const permissionState =
+        // tslint:disable-next-line:no-any
+        await (navigator as any).permissions.query({name: 'notifications'});
     this.state.permissionBlocked = permissionState.state === 'denied';
   }
 

--- a/src/server/apis/dash-data.ts
+++ b/src/server/apis/dash-data.ts
@@ -19,7 +19,7 @@ export class DashData {
     }
 
     const userData = await this.fetchUserData(
-        req.query.login || loginDetails.username, loginDetails.token);
+        req.query.login || loginDetails.username, loginDetails.githubToken);
     res.header('content-type', 'application/json');
     res.send(JSON.stringify(userData, null, 2));
   }

--- a/src/server/apis/settings.ts
+++ b/src/server/apis/settings.ts
@@ -32,7 +32,7 @@ function getRouter(): express.Router {
             query: orgsDetailsQuery,
             fetchPolicy: 'network-only',
             context: {
-              token: loginDetails.token,
+              token: loginDetails.githubToken,
             }
           });
 
@@ -51,7 +51,7 @@ function getRouter(): express.Router {
               let hookEnabled = false;
               if (org.viewerCanAdminister) {
                 const hooks = await github().get(
-                    `orgs/${org.login}/hooks`, loginDetails.token);
+                    `orgs/${org.login}/hooks`, loginDetails.githubToken);
 
                 for (const hook of hooks) {
                   if (hook.config.url === WEBHOOK_URL) {

--- a/src/server/apis/webhook.ts
+++ b/src/server/apis/webhook.ts
@@ -65,7 +65,7 @@ function getRouter(): express.Router {
         if (request.params.action === 'add') {
           try {
             await github().post(
-                `orgs/${request.body.org}/hooks`, loginDetails.token, {
+                `orgs/${request.body.org}/hooks`, loginDetails.githubToken, {
                   name: 'web',
                   active: true,
                   events: [
@@ -90,8 +90,8 @@ function getRouter(): express.Router {
         } else if (request.params.action === 'remove') {
           try {
             const org = request.body.org;
-            const hooks =
-                await github().get(`orgs/${org}/hooks`, loginDetails.token);
+            const hooks = await github().get(
+                `orgs/${org}/hooks`, loginDetails.githubToken);
             let hookId = null;
             for (const hook of hooks) {
               if (hook.config.url === WEBHOOK_URL) {
@@ -106,7 +106,7 @@ function getRouter(): express.Router {
 
             await github().delete(
                 `orgs/${org}/hooks/${hookId}`,
-                loginDetails.token,
+                loginDetails.githubToken,
             );
 
             response.sendStatus(200);

--- a/src/server/controllers/webhook-events.ts
+++ b/src/server/controllers/webhook-events.ts
@@ -67,7 +67,7 @@ export async function handleStatus(hookData: StatusHook): Promise<boolean> {
     },
     fetchPolicy: 'network-only',
     // We use the commit author's token for this request
-    context: {token: loginDetails.token}
+    context: {token: loginDetails.githubToken}
   });
 
   if (!statusPR.data.pullRequests || !statusPR.data.pullRequests.nodes) {

--- a/src/sw/sw.ts
+++ b/src/sw/sw.ts
@@ -36,7 +36,8 @@ const clickEventHandler = {
       // There was a URL provided with the notification payload - open it if
       // the user clicks on the notifications
       const openWindowPromise = self.clients.openWindow(data.url);
-      // Wait for the window to open for letting the browser kill the service worker
+      // Wait for the window to open for letting the browser kill the service
+      // worker
       event.waitUntil(openWindowPromise);
     }
   }

--- a/src/test/server/apis/webhook-test.ts
+++ b/src/test/server/apis/webhook-test.ts
@@ -2,11 +2,11 @@ import test from 'ava';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 
+import {startTestReplayServer} from '../../../replay-server';
 import {handlePullRequestReview, handleStatus} from '../../../server/controllers/webhook-events';
 import {initFirestore} from '../../../utils/firestore';
-import {initSecrets} from '../../../utils/secrets';
 import {initGithub} from '../../../utils/github';
-import {startTestReplayServer} from '../../../replay-server';
+import {initSecrets} from '../../../utils/secrets';
 
 const hookJsonDir = path.join(__dirname, '..', '..', 'static', 'webhook-data');
 
@@ -33,29 +33,33 @@ test.afterEach.cb((t) => {
   t.context.server.close(t.end);
 });
 
-test('Webhook pull_request_review: submitted-state-changes_requested.json', async (t) => {
-  const eventContent = await fs.readJSON(path.join(
-      hookJsonDir,
-      'pull_request_review',
-      'submitted-state-changes_requested.json'));
-  await handlePullRequestReview(eventContent);
+test(
+    'Webhook pull_request_review: submitted-state-changes_requested.json',
+    async (t) => {
+      const eventContent = await fs.readJSON(path.join(
+          hookJsonDir,
+          'pull_request_review',
+          'submitted-state-changes_requested.json'));
+      await handlePullRequestReview(eventContent);
 
-  // TODO: Find way to assert arguments passed to sendNotification()
+      // TODO: Find way to assert arguments passed to sendNotification()
 
-  t.pass();
-});
+      t.pass();
+    });
 
-test('Webhook pull_request_review: submitted-state-approved.json', async (t) => {
-  const eventContent = await fs.readJSON(path.join(
-      hookJsonDir, 'pull_request_review', 'submitted-state-approved.json'));
-  await handlePullRequestReview(eventContent);
+test(
+    'Webhook pull_request_review: submitted-state-approved.json', async (t) => {
+      const eventContent = await fs.readJSON(path.join(
+          hookJsonDir, 'pull_request_review', 'submitted-state-approved.json'));
+      await handlePullRequestReview(eventContent);
 
-  // TODO: Find way to assert arguments passed to sendNotification()
+      // TODO: Find way to assert arguments passed to sendNotification()
 
-  t.pass();
-});
+      t.pass();
+    });
 
-// This is serial to ensure that the Github replay server is used before it's closed.
+// This is serial to ensure that the Github replay server is used before it's
+// closed.
 test.serial('Webhook status: error-travis.json', async (t) => {
   const eventContent =
       await fs.readJSON(path.join(hookJsonDir, 'status', 'error-travis.json'));


### PR DESCRIPTION
This moves tokens into firestore rather than keeping them in memory on the server.

The original desire from everyone was to have tokens nested under a user, for example:

> users > ${username} > tokens > ${token} > ${tokenDetails}

This presents a problem when looking up information when we only have the token. Firestore only supports simply search of document fields on a collection (i.e. search for a user or search for token details).

I ended up using:

> tokens > ${token} > ${token Details}

This can be search for as `Find tokens where the username == 'gauntface'` allowing information look up by a token or a users login.