### PR TITLE
Adding TTL to web push to avoid old notifications forever trying

### DIFF
--- a/src/server/controllers/notifications.ts
+++ b/src/server/controllers/notifications.ts
@@ -21,7 +21,12 @@ export const sendNotification =
   }
 
   return Promise.all(userSubscriptionDetails.map((subDetails) => {
-    return webpush.sendNotification(subDetails.subscription, JSON.stringify(data))
+    const options = {
+        // TTL in seconds (1 Day). After which, notification will not
+        // be delivered.
+        TTL: 24 * 60 * 60,
+    };
+    return webpush.sendNotification(subDetails.subscription, JSON.stringify(data), options)
         .catch(async (err) => {
             // 410 and 404 response from the Web Push module means
             // the subscription is no longer usable.

--- a/src/types/web-push.d.ts
+++ b/src/types/web-push.d.ts
@@ -6,5 +6,5 @@ declare module 'web-push' {
       ): void;
 
   export function sendNotification(
-      subscription: object, payload: string): Promise<void>;
+      subscription: object, payload: string, options: object): Promise<void>;
 }

--- a/src/types/web-push.d.ts
+++ b/src/types/web-push.d.ts
@@ -1,3 +1,7 @@
+type WebPushOptions = {
+    TTL: number;
+};
+
 declare module 'web-push' {
   export function setVapidDetails(
       url: string,
@@ -6,5 +10,5 @@ declare module 'web-push' {
       ): void;
 
   export function sendNotification(
-      subscription: object, payload: string, options: object): Promise<void>;
+      subscription: object, payload: string, options: WebPushOptions): Promise<void>;
 }

--- a/src/types/web-push.d.ts
+++ b/src/types/web-push.d.ts
@@ -1,5 +1,5 @@
 type WebPushOptions = {
-    TTL: number;
+    TTL?: number;
 };
 
 declare module 'web-push' {
@@ -10,5 +10,5 @@ declare module 'web-push' {
       ): void;
 
   export function sendNotification(
-      subscription: object, payload: string, options: WebPushOptions): Promise<void>;
+      subscription: object, payload: string, options?: WebPushOptions): Promise<void>;
 }


### PR DESCRIPTION
I opened up and older version of chrome and got a tonne of notifications.

This makes notifications get dropped if not delivered in 24 hours.

Rationale is that most of us will open github-health at least once a day, so if the notifications haven't been delivered in a day, probably not worth bombarding the user.