### PR TITLE
Using correct requested_reviewer value

### DIFF
--- a/src/server/controllers/webhook-events.ts
+++ b/src/server/controllers/webhook-events.ts
@@ -14,7 +14,7 @@ type ReviewHook = {
 };
 
 type PullRequest = {
-  title: string; user: User; html_url: string; requested_reviewers: Reviewer[];
+  title: string; user: User; html_url: string;;
 };
 
 type RepositoryHook = {
@@ -27,6 +27,7 @@ type Reviewer = {
 
 type PullRequestHook = {
   action: string; pull_request: PullRequest; repository: RepositoryHook;
+  requested_reviewer: Reviewer
 };
 
 type PullRequestReviewHook = {
@@ -122,7 +123,7 @@ export async function handlePullRequest(hookBody: PullRequestHook):
   const pullRequest = hookBody.pull_request;
   const repo = hookBody.repository;
   const user = pullRequest.user;
-  const reviewers = pullRequest.requested_reviewers;
+  const reviewer = hookBody.requested_reviewer;
   const notification = {
     title: `${user.login} requested a review`,
     body: `[${repo.name}] ${pullRequest.title}`,
@@ -133,9 +134,7 @@ export async function handlePullRequest(hookBody: PullRequestHook):
     }
   };
 
-  for (const reviewer of reviewers) {
-    await sendNotification(reviewer.login, notification);
-  }
+  await sendNotification(reviewer.login, notification);
 
   return true;
 }

--- a/src/server/controllers/webhook-events.ts
+++ b/src/server/controllers/webhook-events.ts
@@ -14,7 +14,7 @@ type ReviewHook = {
 };
 
 type PullRequest = {
-  title: string; user: User; html_url: string;;
+  title: string; user: User; html_url: string;
 };
 
 type RepositoryHook = {
@@ -27,7 +27,7 @@ type Reviewer = {
 
 type PullRequestHook = {
   action: string; pull_request: PullRequest; repository: RepositoryHook;
-  requested_reviewer: Reviewer
+  requested_reviewer: Reviewer;
 };
 
 type PullRequestReviewHook = {

--- a/src/test/server/apis/webhook-test.ts
+++ b/src/test/server/apis/webhook-test.ts
@@ -171,7 +171,7 @@ test.serial('Webhook pull_request_review: unknown action', async (t) => {
         login: '',
       },
       html_url: '',
-      requested_reviewers: [],
+      requested_reviewer: {login: ''},
     },
     repository: {
       name: '',
@@ -199,7 +199,6 @@ test.serial('Webhook pull_request_review: unknown review state', async (t) => {
         login: '',
       },
       html_url: '',
-      requested_reviewers: [],
     },
     repository: {
       name: '',
@@ -525,18 +524,8 @@ test.serial('Webhook pull_request: review_requested.json', async (t) => {
       path.join(hookJsonDir, 'pull_request', 'review_requested.json'));
   const handled = await handlePullRequest(eventContent);
   t.deepEqual(handled, true);
-  t.deepEqual(sendStub.callCount, 2);
+  t.deepEqual(sendStub.callCount, 1);
   t.deepEqual(sendStub.args[0], [
-    'gauntface',
-    {
-      title: 'gauntface requested a review',
-      body: '[project-health] Add icon to notification and correcting URL link',
-      requireInteraction: true,
-      icon: '/images/notification-images/icon-192x192.png',
-      data: {url: 'https://github.com/PolymerLabs/project-health/pull/146'}
-    }
-  ]);
-  t.deepEqual(sendStub.args[1], [
     'samuelli',
     {
       title: 'gauntface requested a review',


### PR DESCRIPTION
Use `requested_reviewer` instead of `requested_reviewers` when triggering notifications.