### PR TITLE
Orgs failing to get hooks

### DIFF
--- a/src/server/apis/settings.ts
+++ b/src/server/apis/settings.ts
@@ -60,14 +60,19 @@ function getRouter(): express.Router {
                       `orgs/${org.login}/hooks`, loginDetails.githubToken);
 
                   const hookUrl = getHookUrl(request);
+                  // If the above github get request was successful, we know
+                  // the OAuth app has writes to view the list of hooks.
                   for (const hook of hooks) {
                     if (hook.config.url === hookUrl) {
                       hookEnabled = true;
                     }
                   }
                 } catch (err) {
+                  // This can occur is the user is a public member of an org
+                  // but the OAuth app does not have access to org due to
+                  // org restrictions.
                   console.log(`Unable to get hooks for ${org.login}.`);
-                  hookEnabled = false;
+                  return;
                 }
               }
 
@@ -91,8 +96,12 @@ function getRouter(): express.Router {
           }));
         } catch (err) {
           console.error(err);
-          response.status(500).send('An unhandled error occured: ' +
-              err.message);
+          response.status(500).send({
+            error: {
+              message: 'An unhandled error occured: ' +
+              err.message
+            },
+          });
         }
       });
 

--- a/src/server/apis/settings.ts
+++ b/src/server/apis/settings.ts
@@ -60,8 +60,6 @@ function getRouter(): express.Router {
                       `orgs/${org.login}/hooks`, loginDetails.githubToken);
 
                   const hookUrl = getHookUrl(request);
-                  // If the above github get request was successful, we know
-                  // the OAuth app has writes to view the list of hooks.
                   for (const hook of hooks) {
                     if (hook.config.url === hookUrl) {
                       hookEnabled = true;

--- a/src/server/apis/settings.ts
+++ b/src/server/apis/settings.ts
@@ -55,14 +55,19 @@ function getRouter(): express.Router {
 
               let hookEnabled = false;
               if (org.viewerCanAdminister) {
-                const hooks = await github().get(
-                    `orgs/${org.login}/hooks`, loginDetails.githubToken);
+                try {
+                  const hooks = await github().get(
+                      `orgs/${org.login}/hooks`, loginDetails.githubToken);
 
-                const hookUrl = getHookUrl(request);
-                for (const hook of hooks) {
-                  if (hook.config.url === hookUrl) {
-                    hookEnabled = true;
+                  const hookUrl = getHookUrl(request);
+                  for (const hook of hooks) {
+                    if (hook.config.url === hookUrl) {
+                      hookEnabled = true;
+                    }
                   }
+                } catch (err) {
+                  console.log(`Unable to get hooks for ${org.login}.`);
+                  hookEnabled = false;
                 }
               }
 
@@ -86,7 +91,8 @@ function getRouter(): express.Router {
           }));
         } catch (err) {
           console.error(err);
-          response.status(500).send('An unhandled error occured.');
+          response.status(500).send('An unhandled error occured: ' +
+              err.message);
         }
       });
 

--- a/src/server/apis/settings.ts
+++ b/src/server/apis/settings.ts
@@ -66,9 +66,9 @@ function getRouter(): express.Router {
                     }
                   }
                 } catch (err) {
-                  // This can occur is the user is a public member of an org
-                  // but the OAuth app does not have access to org due to
-                  // org restrictions.
+                  // This can occur if the user is a public member of an org
+                  // but the OAuth app does not have access due to
+                  // org restrictions against GitHub apps.
                   console.log(`Unable to get hooks for ${org.login}.`);
                   return;
                 }


### PR DESCRIPTION
Looking at the logs, it seems that a user might be able to administer hooks, but retrieving the hooks isn't an option. If that is the case, the error will be caught and the hook will be treated as not enabled.

This will at least make the UI work, but I fear we may need to treat the hook as though it can't be administered.