### PR TITLE
Adding analytics to project-health

### DIFF
--- a/gulp-tasks/build-sw.js
+++ b/gulp-tasks/build-sw.js
@@ -1,11 +1,12 @@
 const path = require('path');
-const {buildTypescript} = require('./utils/build-typescript');
+const {buildBrowserTypescript} = require('./utils/build-browser-typescript');
 
 function buildSW() {
+  const srcDir = path.join(global.__buildConfig.src, 'sw');
+  const tsConfigPath = path.join(srcDir, 'tsconfig.json');
   const destDir = path.join(global.__buildConfig.dest, 'sw');
-  const tsConfigPath =
-      path.join(global.__buildConfig.src, 'sw', 'tsconfig.json');
-  return buildTypescript(tsConfigPath, destDir);
+
+  return buildBrowserTypescript(srcDir, tsConfigPath, destDir);
 };
 buildSW.displayName = `build-sw`;
 

--- a/src/client/public/scripts/dash/dash.ts
+++ b/src/client/public/scripts/dash/dash.ts
@@ -439,7 +439,7 @@ async function start() {
 
       const swMessage = event.data;
       if (swMessage.action === 'push-received') {
-        performLongPoll(userLogin);
+        updateDashboard(userLogin);
       }
     });
   }

--- a/src/client/require-login/index.html
+++ b/src/client/require-login/index.html
@@ -17,4 +17,12 @@
 <!-- The crossorigin attribute sends credentials for requests to the same origin. -->
 <script src="/scripts/dash/dash.js" crossorigin></script>
 
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-114703954-1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag() { dataLayer.push(arguments); }
+  gtag('js', new Date());
+  gtag('config', 'UA-114703954-1');
+</script>
+
 </html>

--- a/src/client/require-login/settings.html
+++ b/src/client/require-login/settings.html
@@ -24,7 +24,9 @@
           </div>
         </div>
         <div class="settings-toggle-item__details">
-          <div class="small-heading">Push Notifications <span class="push-component__status"></span></div>
+          <div class="small-heading">Push Notifications
+            <span class="push-component__status"></span>
+          </div>
           <p>Push notifications are enabled. Toggle to no longer receive push notifications on this device.</p>
         </div>
       </div>
@@ -32,8 +34,9 @@
 
     <section>
       <h2>Organization Permissions</h2>
-      <p>Each organization must add a webhook before any push notifications can be
-        received by anyone in the organization. <a target="_blank" href="https://github.com/settings/connections/applications/23b7d82aec29a3a1a2a8">Review Project-Health Permissions</a>
+      <p>Each organization must add a webhook before any push notifications can be received by anyone in the organization.
+        <a
+          target="_blank" href="https://github.com/settings/connections/applications/23b7d82aec29a3a1a2a8">Review Project-Health Permissions</a>
       </p>
       <div class="org-webhook-list"></div>
     </section>
@@ -42,5 +45,13 @@
 
 <script src="/scripts/settings/push-component.js"></script>
 <script src="/scripts/settings/org-webhook-list.js"></script>
+
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-114703954-1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag() { dataLayer.push(arguments); }
+  gtag('js', new Date());
+  gtag('config', 'UA-114703954-1');
+</script>
 
 </html>

--- a/src/server/controllers/notifications.ts
+++ b/src/server/controllers/notifications.ts
@@ -22,9 +22,9 @@ export const sendNotification =
 
   return Promise.all(userSubscriptionDetails.map((subDetails) => {
     const options = {
-      // TTL in seconds (1 Day). After which, notification will not
+      // TTL in seconds (12 Hours). After which, notification will not
       // be delivered.
-      TTL: 24 * 60 * 60,
+      TTL: 12 * 60 * 60,
     };
     return webpush
         .sendNotification(

--- a/src/sw/analytics.ts
+++ b/src/sw/analytics.ts
@@ -1,0 +1,80 @@
+import {} from '.';
+declare var self: ServiceWorkerGlobalScope;
+
+// Make use of Google Analytics Measurement Protocol.
+// https://developers.google.com/analytics/devguides/collection/protocol/v1/reference
+export class Analytics {
+  private trackingId: string;
+
+  constructor(trackingId: string) {
+    this.trackingId = trackingId;
+  }
+
+  async trackEvent(
+      clientId: string,
+      eventAction: string,
+      eventValue: string,
+      optionalParams?: {}) {
+    if (!this.trackingId) {
+      console.error('You need to set a trackingId, for example:');
+      console.error('self.analytics.trackingId = \'UA-XXXXXXXX-X\';');
+
+      // We want this to be a safe method, so avoid throwing Unless
+      // It's absolutely necessary.
+      return;
+    }
+
+    if (typeof eventAction === 'undefined' &&
+        typeof eventValue === 'undefined') {
+      console.warn(
+          'sendAnalyticsEvent() called with no eventAction or ' +
+          'eventValue.');
+      return;
+    }
+
+    let payloadData: {[key: string]: string|number} = {
+      // Version Number
+      v: 1,
+      // Client ID
+      cid: clientId,
+      // Tracking ID
+      tid: this.trackingId,
+      // Hit Type
+      t: 'event',
+      // Data Source
+      ds: 'serviceworker',
+      // Event Category
+      ec: 'serviceworker',
+      // Event Action
+      ea: eventAction,
+      // Event Value
+      ev: eventValue,
+    };
+
+    if (optionalParams) {
+      payloadData = Object.assign(payloadData, optionalParams);
+    }
+
+    const payloadString =
+        Object.keys(payloadData)
+            .filter((analyticsKey: string) => {
+              return payloadData[analyticsKey];
+            })
+            .map((analyticsKey) => {
+              return `${analyticsKey}=` +
+                  encodeURIComponent(payloadData[analyticsKey].toString());
+            })
+            .join('&');
+
+    const response = await fetch('https://www.google-analytics.com/collect', {
+      method: 'post',
+      body: payloadString,
+    });
+
+    if (!response.ok) {
+      const responseText = await response.text();
+      console.error(`Bad response from Google Analytics [${response.status}] ${
+          responseText}`);
+    }
+  }
+}

--- a/src/sw/sw.ts
+++ b/src/sw/sw.ts
@@ -8,13 +8,14 @@ const analytics = new Analytics('UA-114703954-1');
 
 async function pingAnalytics(eventAction: string, eventValue: string) {
   let clientID = 'unknown-client-id';
-  console.log('Ping Analytics');
+
   if ('pushManager' in self.registration) {
     const subscription = await self.registration.pushManager.getSubscription();
     if (subscription) {
       clientID = subscription.endpoint;
     }
   }
+
   await analytics.trackEvent(clientID, eventAction, eventValue);
 }
 

--- a/src/sw/tsconfig.json
+++ b/src/sw/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2015",
-    "module": "ES6",
+    "target": "es2015",
+    "module": "es2015",
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
Fixes #199

Will track page views and push events (although this won't use the client ID, instead the subscription)