### PR TITLE
Fix jimp error when pixel test fails because of dimensions

### DIFF
--- a/src/client/public/styles/base.css
+++ b/src/client/public/styles/base.css
@@ -3,7 +3,7 @@ body {
   font-size: 16px;
   max-width: var(--max-desktop-width);
   margin: 0 auto;
-  padding: var(--padding);
+  padding: 30px;
 }
 
 h1 {

--- a/src/client/public/styles/base.css
+++ b/src/client/public/styles/base.css
@@ -3,7 +3,7 @@ body {
   font-size: 16px;
   max-width: var(--max-desktop-width);
   margin: 0 auto;
-  padding: 30px;
+  padding: var(--padding);
 }
 
 h1 {

--- a/src/pixel-tester.ts
+++ b/src/pixel-tester.ts
@@ -31,17 +31,19 @@ function imagesMatch(
         return;
       }
 
+      let matches = true;
       if (img1.width !== img2.width || img1.height !== img2.height) {
-        resolve(false);
+        matches = false;
       }
 
       const diff = new PNG({width: img1.width, height: img1.height});
-      const matches =
+      const numPixelsDifferent =
           pixelmatch(img1.data, img2.data, diff.data, img1.width, img1.height, {
             threshold: 0.1
-          }) === 0;
+          });
+      matches = matches && numPixelsDifferent === 0;
 
-      // Write out diff file.
+      // Wait till diff file is written before resolving.
       diff.pack().pipe(fs.createWriteStream(diffPath)).on('finish', () => {
         resolve(matches);
       });

--- a/src/server/apis/dash-data.ts
+++ b/src/server/apis/dash-data.ts
@@ -32,8 +32,7 @@ async function outgoingHandler(req: express.Request, res: express.Response) {
       loginDetails.githubToken,
   );
 
-  res.header('content-type', 'application/json');
-  res.send(JSON.stringify(userData, null, 2));
+  res.json(userData);
 }
 
 /**
@@ -133,6 +132,7 @@ export async function fetchOutgoingData(
     prs: outgoingPrs.sort((a, b) => b.createdAt - a.createdAt),
   };
 }
+
 /**
  * Handles a response for incoming pull requests.
  */
@@ -148,8 +148,7 @@ async function incomingHandler(req: express.Request, res: express.Response) {
       loginDetails.githubToken,
   );
 
-  res.header('content-type', 'application/json');
-  res.send(JSON.stringify(userData, null, 2));
+  res.json(userData);
 }
 
 /**

--- a/src/server/dash-server.ts
+++ b/src/server/dash-server.ts
@@ -4,8 +4,6 @@ import * as express from 'express';
 import {Server} from 'http';
 import * as path from 'path';
 
-import {firestore} from '../utils/firestore';
-
 import {getRouter as getDashRouter} from './apis/dash-data';
 import {getRouter as getGitHubHookRouter} from './apis/github-webhook';
 import {getRouter as getLoginRouter} from './apis/login';
@@ -51,8 +49,6 @@ export class DashServer {
     app.use('/api/settings/', getSettingsRouter());
     app.use('/api/updates/', getUpdatesRouter());
 
-    app.get('/firestore-test', this.handleFirestoreTest.bind(this));
-
     this.app = app;
   }
 
@@ -94,13 +90,5 @@ export class DashServer {
         resolve();
       });
     });
-  }
-
-  async handleFirestoreTest(_req: express.Request, res: express.Response) {
-    const colRef = firestore().collection('test');
-    const snapshot = await colRef.get();
-    const data = snapshot.docs.map((doc) => doc.data());
-    res.header('content-type', 'application/json');
-    res.send(JSON.stringify(data, null, 2));
   }
 }


### PR DESCRIPTION
This change also adds usage of `res.json()` and removes unused firestore test endpoint.