### PR TITLE
Loghook duplicate docs

### DIFF
--- a/src/server/apis/github-webhook.ts
+++ b/src/server/apis/github-webhook.ts
@@ -31,12 +31,11 @@ function getRouter(): express.Router {
         }
 
         try {
-          if (!await hooksModel.isNewHook(eventDelivery)) {
+          const loggedHook = await hooksModel.logHook(eventDelivery);
+          if (!loggedHook) {
             response.status(202).send('Duplicate Event');
             return;
           }
-
-          await hooksModel.logHook(eventDelivery);
 
           let handled = false;
           // List of these events available here:

--- a/src/server/models/hooksModel.ts
+++ b/src/server/models/hooksModel.ts
@@ -2,7 +2,7 @@ import {firestore} from '../../utils/firestore';
 
 const HOOK_COLLECTION_NAME = 'github-event-deliveries';
 
-export const HOOK_MAX_AGE = 60 * 1000;
+export const HOOK_MAX_AGE = 10 * 60 * 1000;
 
 class HooksModel {
   async isNewHook(hookDelivery: string): Promise<boolean> {
@@ -16,7 +16,7 @@ class HooksModel {
   async logHook(hookDelivery: string): Promise<void> {
     const hookDoc =
         await firestore().collection(HOOK_COLLECTION_NAME).doc(hookDelivery);
-    await hookDoc.create({received: true, timestamp: Date.now()});
+    await hookDoc.set({received: true, timestamp: Date.now()});
   }
 
   async cleanHooks() {

--- a/src/test/server/models/hooksModel-test.ts
+++ b/src/test/server/models/hooksModel-test.ts
@@ -30,40 +30,43 @@ test.afterEach.always(async (t) => {
 });
 
 test.serial('should return true for new', async (t) => {
-  const value = await hooksModel.isNewHook(TEST_HOOK_STRING);
+  const value = await hooksModel.logHook(TEST_HOOK_STRING);
   t.deepEqual(value, true);
 });
 
-test.serial('should set, get and delete commit details', async (t) => {
-  await hooksModel.logHook(TEST_HOOK_STRING);
+test.serial('should set, get and delete hook details correctly', async (t) => {
+  let value = await hooksModel.logHook(TEST_HOOK_STRING);
+  t.deepEqual(value, true);
 
-  let value = await hooksModel.isNewHook(TEST_HOOK_STRING);
+  value = await hooksModel.logHook(TEST_HOOK_STRING);
   t.deepEqual(value, false);
 
   await hooksModel.deleteHook(TEST_HOOK_STRING);
 
-  value = await hooksModel.isNewHook(TEST_HOOK_STRING);
+  value = await hooksModel.logHook(TEST_HOOK_STRING);
   t.deepEqual(value, true);
 });
 
-test.serial('should clean old commit details', async (t) => {
+test.serial('should clean old hook details', async (t) => {
   let fakeTime = 0;
   sinon.stub(Date, 'now').callsFake(() => {
     return fakeTime;
   });
 
-  await hooksModel.logHook(TEST_HOOK_STRING);
+  let value = await hooksModel.logHook(TEST_HOOK_STRING);
+  t.deepEqual(value, true);
 
   fakeTime += HOOK_MAX_AGE + 1;
-  await hooksModel.logHook(TEST_HOOK_STRING_2);
+  value = await hooksModel.logHook(TEST_HOOK_STRING_2);
+  t.deepEqual(value, true);
 
   await hooksModel.cleanHooks();
 
   // This should be treated as "old" and removed
-  let value = await hooksModel.isNewHook(TEST_HOOK_STRING);
+  value = await hooksModel.logHook(TEST_HOOK_STRING);
   t.deepEqual(value, true);
 
   // This should be treated as new enough to avoid cleaning
-  value = await hooksModel.isNewHook(TEST_HOOK_STRING_2);
+  value = await hooksModel.logHook(TEST_HOOK_STRING_2);
   t.deepEqual(value, false);
 });


### PR DESCRIPTION
The error outlined in  #246 is caused by the use of `document.create()` which basically prevents firestore from overwriting a document if it already exists.

The logic that would create a hook, checks to see if the hook exists before creating a new doc, so this error suggests that there is a race condition.

I think the best option to overcome this is attempt to create the document and handle this error gracefully (i.e. the doc exists which means another request is handling the push). While this isn't ideal and the code is ugly it does work.

I've [filed an issue with the firestore SDK](https://github.com/firebase/firebase-js-sdk/issues/553) to see if the error code can be used instead of the error message check that is in this PR.

Should fix #246.