### PR TITLE
Adding support to check if automerge should be available

### DIFF
--- a/replays/Webhook-status:-pending-travis.json/CommitToPR-1e4d484c9717bdbf704a4ecd84761a4ac049605b
+++ b/replays/Webhook-status:-pending-travis.json/CommitToPR-1e4d484c9717bdbf704a4ecd84761a4ac049605b
@@ -1,0 +1,46 @@
+{
+  "data": {
+    "pullRequests": {
+      "nodes": [
+        {
+          "id": "MDExOlB1bGxSZXF1ZXN0MTY2Njk1NzY1",
+          "number": 111,
+          "title": "Webhooks",
+          "bodyText": "Adds ability to remove hooks\nSets initial state correctly.",
+          "state": "MERGED",
+          "url": "https://github.com/PolymerLabs/project-health/pull/111",
+          "repository": {
+            "name": "project-health",
+            "owner": {
+              "login": "PolymerLabs",
+              "__typename": "Organization"
+            },
+            "__typename": "Repository"
+          },
+          "author": {
+            "login": "gauntface",
+            "__typename": "User"
+          },
+          "commits": {
+            "nodes": [
+              {
+                "commit": {
+                  "oid": "c3b7fd28b5d01edc39b5d890e93a44ab31397d3d",
+                  "status": {
+                    "state": "SUCCESS",
+                    "__typename": "Status"
+                  },
+                  "__typename": "Commit"
+                },
+                "__typename": "PullRequestCommit"
+              }
+            ],
+            "__typename": "PullRequestCommitConnection"
+          },
+          "__typename": "PullRequest"
+        }
+      ],
+      "__typename": "SearchResultItemConnection"
+    }
+  }
+}

--- a/src/client/public/scripts/dash/auto-merge-events.ts
+++ b/src/client/public/scripts/dash/auto-merge-events.ts
@@ -56,6 +56,10 @@ function requestRender() {
 
 export function getAutoMergeOptions(pr: api.OutgoingPullRequest):
     TemplateResult[] {
+  if (!pr.automergeAvailable) {
+    return [];
+  }
+
   const isOpen =
       automergeOpenStates[pr.id] ? automergeOpenStates[pr.id] : false;
   const toggleCb = () => {

--- a/src/server/apis/dash-data/fetch-outgoing-data.ts
+++ b/src/server/apis/dash-data/fetch-outgoing-data.ts
@@ -184,15 +184,28 @@ async function getAllPRInfo(
             pr.repository.owner.login,
             pr.repository.name,
             ),
-        pullRequestsModel.getAutomergeOpts(pr.id),
+        pullRequestsModel.getAllPRData(pr.id),
       ]);
 
       const repoDetails = results[0];
-      const automergeOpts = results[1];
+      const prDetails = results[1];
+
+      let automergeAvailable = false;
+      let automergeOpts = null;
+      if (prDetails) {
+        if (prDetails.commits && Object.keys(prDetails.commits).length > 0) {
+          // If we have commit data, then we have status hooks configured.
+          automergeAvailable = true;
+          if (prDetails.automerge) {
+            automergeOpts = prDetails.automerge;
+          }
+        }
+      }
 
       const fullPR: api.OutgoingPullRequest = {
         ...outgoingPr,
         repoDetails,
+        automergeAvailable,
         automergeOpts,
         mergeable: pr.mergeable,
       };

--- a/src/server/models/pullRequestsModel.ts
+++ b/src/server/models/pullRequestsModel.ts
@@ -53,6 +53,16 @@ class PullRequestsModel {
     return prData.commits[commitId];
   }
 
+  async getAllPRData(prId: string): Promise<null|PRDetails> {
+    const prSnapshot =
+        await firestore().collection(PR_COLLECTION_NAME).doc(prId).get();
+    if (!prSnapshot.exists) {
+      return null;
+    }
+
+    return prSnapshot.data() as PRDetails;
+  }
+
   async getAutomergeOpts(prId: string): Promise<null|AutomergeOpts> {
     const prSnapshot =
         await firestore().collection(PR_COLLECTION_NAME).doc(prId).get();

--- a/src/test/server/apis/outgoing-prs-2-test.ts
+++ b/src/test/server/apis/outgoing-prs-2-test.ts
@@ -68,6 +68,7 @@ test('dashoutgoing2: requested changes', (t) => {
   t.deepEqual(t.context.prsById.get('14'), {
     author: 'project-health2',
     automergeOpts: null,
+    automergeAvailable: false,
     avatarUrl: 'https://avatars3.githubusercontent.com/u/34584974?v=4',
     createdAt: 1520881768000,
     events: [
@@ -100,6 +101,7 @@ test('dashoutgoing2: review with comments', (t) => {
   t.deepEqual(t.context.prsById.get('13'), {
     author: 'project-health2',
     automergeOpts: null,
+    automergeAvailable: false,
     avatarUrl: 'https://avatars3.githubusercontent.com/u/34584974?v=4',
     createdAt: 1520468329000,
     events: [
@@ -135,6 +137,7 @@ test('dashoutgoing2: review with comments2', (t) => {
   t.deepEqual(t.context.prsById.get('11'), {
     author: 'project-health2',
     automergeOpts: null,
+    automergeAvailable: false,
     avatarUrl: 'https://avatars3.githubusercontent.com/u/34584974?v=4',
     createdAt: 1518042329000,
     events: [
@@ -170,6 +173,7 @@ test('dashoutgoing2: ready to merge', (t) => {
   t.deepEqual(t.context.prsById.get('10'), {
     author: 'project-health2',
     automergeOpts: null,
+    automergeAvailable: false,
     avatarUrl: 'https://avatars3.githubusercontent.com/u/34584974?v=4',
     createdAt: 1518031465000,
     events: [
@@ -204,6 +208,7 @@ test.failing('dashoutgoing2: changes requested, new commit', (t) => {
   t.deepEqual(t.context.prsById.get('9'), {
     author: 'project-health2',
     automergeOpts: null,
+    automergeAvailable: false,
     avatarUrl: 'https://avatars3.githubusercontent.com/u/34584974?v=4',
     createdAt: 1517426339000,
     events: [
@@ -237,6 +242,7 @@ test('dashoutgoing2: no review', (t) => {
   t.deepEqual(t.context.prsById.get('4'), {
     author: 'project-health2',
     automergeOpts: null,
+    automergeAvailable: false,
     avatarUrl: 'https://avatars3.githubusercontent.com/u/34584974?v=4',
     createdAt: 1516753159000,
     events: [],
@@ -261,6 +267,7 @@ test('dashoutgoing2: basic requested changes', (t) => {
   t.deepEqual(t.context.prsById.get('3'), {
     author: 'project-health2',
     automergeOpts: null,
+    automergeAvailable: false,
     avatarUrl: 'https://avatars3.githubusercontent.com/u/34584974?v=4',
     createdAt: 1516750523000,
     events: [

--- a/src/test/server/apis/outgoing-prs-test.ts
+++ b/src/test/server/apis/outgoing-prs-test.ts
@@ -102,6 +102,7 @@ test('dashoutgoing: outgoing PR, review with my own replies', (t) => {
     },
     mergeable: MergeableState.MERGEABLE,
     automergeOpts: null,
+    automergeAvailable: false,
   });
 });
 
@@ -125,6 +126,7 @@ test('dashoutgoing: Outgoing PR, no reviewers', (t) => {
     },
     mergeable: MergeableState.MERGEABLE,
     automergeOpts: null,
+    automergeAvailable: false,
   });
 });
 
@@ -153,6 +155,7 @@ test('dashoutgoing: Outgoing PR, changes requested', (t) => {
     },
     mergeable: MergeableState.MERGEABLE,
     automergeOpts: null,
+    automergeAvailable: false,
   });
 });
 
@@ -181,6 +184,7 @@ test('dashoutgoing: Outgoing PR, approved, ready to merge', (t) => {
     },
     mergeable: MergeableState.MERGEABLE,
     automergeOpts: null,
+    automergeAvailable: false,
   });
 });
 
@@ -211,6 +215,7 @@ test('dashoutgoing: Outgoing PR, has 1 commented review', (t) => {
     },
     mergeable: MergeableState.MERGEABLE,
     automergeOpts: null,
+    automergeAvailable: false,
   });
 });
 
@@ -232,6 +237,7 @@ test('dashoutgoing: Outgoing PR, requested reviews, no reviews', (t) => {
     },
     mergeable: MergeableState.MERGEABLE,
     automergeOpts: null,
+    automergeAvailable: false,
   });
 });
 
@@ -261,6 +267,7 @@ test('dashoutgoing: review requested changes then approved', (t) => {
     },
     mergeable: MergeableState.MERGEABLE,
     automergeOpts: null,
+    automergeAvailable: false,
   });
 });
 
@@ -289,6 +296,7 @@ test('dashoutgoing: with success status', (t) => {
     },
     mergeable: MergeableState.MERGEABLE,
     automergeOpts: null,
+    automergeAvailable: false,
   });
 });
 
@@ -317,6 +325,7 @@ test('dashoutgoing: with pending status', (t) => {
     },
     mergeable: MergeableState.MERGEABLE,
     automergeOpts: null,
+    automergeAvailable: true,
   });
 });
 
@@ -345,6 +354,7 @@ test('dashoutgoing: with error status', (t) => {
     },
     mergeable: MergeableState.MERGEABLE,
     automergeOpts: null,
+    automergeAvailable: true,
   });
 });
 
@@ -373,5 +383,6 @@ test('dashoutgoing: with failing status', (t) => {
     },
     mergeable: MergeableState.MERGEABLE,
     automergeOpts: null,
+    automergeAvailable: true,
   });
 });

--- a/src/test/server/apis/webhook-automerge-test.ts
+++ b/src/test/server/apis/webhook-automerge-test.ts
@@ -99,7 +99,7 @@ test.serial(
     });
 
 test.serial(
-    '[webhook to automerge]: Should not handle if PR has a non-success state',
+    '[webhook to automerge]: should not handle if PR has a non-success state',
     async (t) => {
       t.context.sandbox.stub(userModel, 'getLoginDetails')
           .callsFake((username: string) => {
@@ -114,7 +114,9 @@ test.serial(
           t.context.sandbox.stub(commitPRUtil, 'getPRDetailsFromCommit')
               .callsFake(() => {
                 return {
+                  id: 'test-pr-id',
                   commit: {
+                    oid: 'test-commit',
                     state: 'PENDING',
                   }
                 };
@@ -155,7 +157,9 @@ test.serial(
           });
 
       const prDetails = {
+        id: 'test-pr-id',
         commit: {
+          oid: 'test-commit',
           state: 'SUCCESS',
         }
       };
@@ -205,10 +209,12 @@ test.serial(
           });
 
       const prDetails = {
+        id: 'test-pr-id',
         title: 'pr-title',
         url: 'http://inject-url.com',
         author: 'project-health1',
         commit: {
+          oid: 'test-commit',
           state: 'SUCCESS',
         }
       };
@@ -274,6 +280,7 @@ test.serial(
           });
 
       const prDetails = {
+        id: 'test-pr-id',
         title: 'pr-title',
         url: 'http://inject-url.com',
         author: 'project-health1',

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -20,6 +20,7 @@ export interface OutgoingPullRequest extends PullRequest {
   repoDetails: RepoDetails;
   mergeable: 'MERGEABLE'|'CONFLICTING'|'UNKNOWN';
   automergeOpts: AutomergeOpts|null;
+  automergeAvailable: boolean;
 }
 
 export interface PullRequest {
@@ -77,9 +78,13 @@ export interface JSONAPIResponse<T> {
   data?: T;
 }
 
-export interface LoginResponse { status: string; }
+export interface LoginResponse {
+  status: string;
+}
 
-export interface LastKnownResponse { lastKnownUpdate: string|null; }
+export interface LastKnownResponse {
+  lastKnownUpdate: string|null;
+}
 
 /** Not necessarily actionable. */
 
@@ -187,7 +192,9 @@ export interface ErrorPayload {
   message: string;
 }
 
-export interface NotificationURLData { url: string; }
+export interface NotificationURLData {
+  url: string;
+}
 
 export type SWClientMessage<T> = {
   action: 'push-received',


### PR DESCRIPTION
When a status event is received for a commit,we now track it on Firebase regardless of status.

This means that we can now offer automerage *only* when hooks are enabled.