### PR TITLE
Cleanup existing notifications for PR's that may be closed or merged.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6476,7 +6476,7 @@
     "fsevents": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
-      "integrity": "sha1-EfgjGPX+e7LNIpZaEI6TBiCCFtg=",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
       "dev": true,
       "optional": true,
       "requires": {

--- a/src/server/apis/auto-merge.ts
+++ b/src/server/apis/auto-merge.ts
@@ -4,7 +4,7 @@ import * as express from 'express';
 import {pullRequestsModel} from '../models/pullRequestsModel';
 import {userModel} from '../models/userModel';
 
-function getRouter(): express.Router {
+export function getRouter(): express.Router {
   const automergeRouter = express.Router();
   automergeRouter.post(
       '/set-merge-option/',
@@ -58,5 +58,3 @@ function getRouter(): express.Router {
 
   return automergeRouter;
 }
-
-export {getRouter};

--- a/src/server/apis/check-pr-state.ts
+++ b/src/server/apis/check-pr-state.ts
@@ -1,0 +1,95 @@
+import * as express from 'express';
+import gql from 'graphql-tag';
+
+import {CheckPRPayload, NotificationPullRequestData} from '../../types/api';
+import {PRStateQuery} from '../../types/gql-types';
+import {github} from '../../utils/github';
+// import {github} from '../../utils/github';
+import {userModel} from '../models/userModel';
+
+function getRouter(): express.Router {
+  const checkPRStateRouter = express.Router();
+  checkPRStateRouter.post(
+      '/', async (request: express.Request, response: express.Response) => {
+        try {
+          if (!request.body) {
+            response.status(400).send('No body.');
+            return;
+          }
+
+          const loginDetails = await userModel.getLoginFromRequest(request);
+          if (!loginDetails) {
+            response.status(400).send('No login details.');
+            return;
+          }
+
+          const pullRequests = request.body;
+
+          const prIds: string[] = [];
+          for (const pullRequest of pullRequests) {
+            if (!pullRequest.gqlId) {
+              response.status(400).send('No gqlId.');
+              return;
+            }
+
+            prIds.push(pullRequest.gqlId);
+          }
+
+          const pullRequestData: NotificationPullRequestData[] = [];
+          if (prIds.length > 0) {
+            // tslint:disable-next-line:no-any
+            const results = await github().query<PRStateQuery>({
+              query: prStateQuery,
+              variables: {
+                prIds,
+              },
+              fetchPolicy: 'network-only',
+              context: {token: loginDetails.githubToken}
+            });
+
+            if (results.data.nodes) {
+              for (const node of results.data.nodes) {
+                if (!node) {
+                  continue;
+                }
+
+                if (node.__typename !== 'PullRequest') {
+                  continue;
+                }
+
+                if (node.state && node.id) {
+                  pullRequestData.push({
+                    gqlId: node.id,
+                    state: node.state,
+                  });
+                }
+              }
+            }
+          }
+
+
+          const payload: CheckPRPayload = {
+            pullRequests: pullRequestData,
+          };
+          response.json(payload);
+        } catch (err) {
+          console.error(err);
+          response.status(500).send('An unhandled error occured.');
+        }
+      });
+
+  return checkPRStateRouter;
+}
+
+export {getRouter};
+
+const prStateQuery = gql`
+query PRState($prIds: [ID!]!) {
+  nodes(ids: $prIds) {
+    ...on PullRequest {
+      id
+      state
+    }
+  }
+}
+`;

--- a/src/server/apis/check-pr-state.ts
+++ b/src/server/apis/check-pr-state.ts
@@ -4,10 +4,9 @@ import gql from 'graphql-tag';
 import {CheckPRPayload, NotificationPullRequestData} from '../../types/api';
 import {PRStateQuery} from '../../types/gql-types';
 import {github} from '../../utils/github';
-// import {github} from '../../utils/github';
 import {userModel} from '../models/userModel';
 
-function getRouter(): express.Router {
+export function getRouter(): express.Router {
   const checkPRStateRouter = express.Router();
   checkPRStateRouter.post(
       '/', async (request: express.Request, response: express.Response) => {
@@ -23,21 +22,10 @@ function getRouter(): express.Router {
             return;
           }
 
-          const pullRequests = request.body;
-
-          const prIds: string[] = [];
-          for (const pullRequest of pullRequests) {
-            if (!pullRequest.gqlId) {
-              response.status(400).send('No gqlId.');
-              return;
-            }
-
-            prIds.push(pullRequest.gqlId);
-          }
+          const prIds = request.body;
 
           const pullRequestData: NotificationPullRequestData[] = [];
           if (prIds.length > 0) {
-            // tslint:disable-next-line:no-any
             const results = await github().query<PRStateQuery>({
               query: prStateQuery,
               variables: {
@@ -67,7 +55,6 @@ function getRouter(): express.Router {
             }
           }
 
-
           const payload: CheckPRPayload = {
             pullRequests: pullRequestData,
           };
@@ -80,8 +67,6 @@ function getRouter(): express.Router {
 
   return checkPRStateRouter;
 }
-
-export {getRouter};
 
 const prStateQuery = gql`
 query PRState($prIds: [ID!]!) {

--- a/src/server/apis/github-webhook.ts
+++ b/src/server/apis/github-webhook.ts
@@ -12,7 +12,7 @@ export interface WebHookHandleResponse {
   message: string|null;
 }
 
-function getRouter(): express.Router {
+export function getRouter(): express.Router {
   const githubHookRouter = express.Router();
   githubHookRouter.post(
       '/', async (request: express.Request, response: express.Response) => {
@@ -77,5 +77,3 @@ function getRouter(): express.Router {
       });
   return githubHookRouter;
 }
-
-export {getRouter};

--- a/src/server/apis/login.ts
+++ b/src/server/apis/login.ts
@@ -78,10 +78,8 @@ async function handleLoginRequest(request: express.Request):
   };
 }
 
-function getRouter(): express.Router {
+export function getRouter(): express.Router {
   const loginRouter = express.Router();
   loginRouter.post('/', createAPIRoute(handleLoginRequest));
   return loginRouter;
 }
-
-export {getRouter};

--- a/src/server/apis/manage-webhook.ts
+++ b/src/server/apis/manage-webhook.ts
@@ -87,7 +87,7 @@ async function removeWebHook(
   }
 }
 
-function getRouter(): express.Router {
+export function getRouter(): express.Router {
   const webhookRouter = express.Router();
   webhookRouter.post(
       '/:action',
@@ -114,5 +114,3 @@ function getRouter(): express.Router {
 
   return webhookRouter;
 }
-
-export {getRouter};

--- a/src/server/apis/push-subscription.ts
+++ b/src/server/apis/push-subscription.ts
@@ -4,7 +4,7 @@ import * as express from 'express';
 import {getSubscriptionModel} from '../models/pushSubscriptionModel';
 import {userModel} from '../models/userModel';
 
-function getRouter(): express.Router {
+export function getRouter(): express.Router {
   const pushSubscriptionRouter = express.Router();
   pushSubscriptionRouter.post(
       '/:action',
@@ -46,5 +46,3 @@ function getRouter(): express.Router {
 
   return pushSubscriptionRouter;
 }
-
-export {getRouter};

--- a/src/server/apis/settings.ts
+++ b/src/server/apis/settings.ts
@@ -8,7 +8,7 @@ import {userModel} from '../models/userModel';
 
 import {getHookUrl} from './manage-webhook';
 
-function getRouter(): express.Router {
+export function getRouter(): express.Router {
   const settingsRouter = express.Router();
   settingsRouter.post(
       '/orgs.json',
@@ -128,8 +128,6 @@ function getRouter(): express.Router {
 
   return settingsRouter;
 }
-
-export {getRouter};
 
 const orgsDetailsQuery = gql`
   query OrgDetails {

--- a/src/server/apis/updates.ts
+++ b/src/server/apis/updates.ts
@@ -56,10 +56,8 @@ async function handleLastKnownUpdate(request: express.Request):
   };
 }
 
-function getRouter(): express.Router {
+export function getRouter(): express.Router {
   const loginRouter = express.Router();
   loginRouter.get('/last-known.json', createAPIRoute(handleLastKnownUpdate));
   return loginRouter;
 }
-
-export {getRouter};

--- a/src/server/controllers/webhook-events/status.ts
+++ b/src/server/controllers/webhook-events/status.ts
@@ -28,6 +28,9 @@ async function handleFailingStatus(
       requireInteraction: false,
       data: {
         url: prDetails.url,
+        pullRequest: {
+          gqlId: prDetails.gqlId,
+        },
       },
       tag: getPRTag(repo.owner.login, repo.name, prDetails.number),
     });
@@ -74,6 +77,9 @@ async function handleSuccessStatus(
         requireInteraction: false,
         data: {
           url: prDetails.url,
+          pullRequest: {
+            gqlId: prDetails.gqlId,
+          },
         },
         tag: getPRTag(repo.owner.login, repo.name, prDetails.number),
       });
@@ -96,6 +102,7 @@ async function handleSuccessStatus(
       requireInteraction: false,
       data: {
         url: prDetails.url,
+        pullRequest: {gqlId: prDetails.gqlId},
       },
       tag: getPRTag(repo.owner.login, repo.name, prDetails.number),
     });

--- a/src/server/dash-server.ts
+++ b/src/server/dash-server.ts
@@ -6,6 +6,7 @@ import {Server} from 'http';
 import * as path from 'path';
 
 import {getRouter as getAutomergeRouter} from './apis/auto-merge';
+import {getRouter as getCheckPRStateRouter} from './apis/check-pr-state';
 import {getRouter as getDashRouter} from './apis/dash-data';
 import {getRouter as getGitHubHookRouter} from './apis/github-webhook';
 import {getRouter as getLoginRouter} from './apis/login';
@@ -88,6 +89,7 @@ export class DashServer {
     app.use('/api/settings/', getSettingsRouter());
     app.use('/api/updates/', getUpdatesRouter());
     app.use('/api/auto-merge/', getAutomergeRouter());
+    app.use('/api/check-pr-state/', getCheckPRStateRouter());
   }
 
   listen(): Promise<string> {

--- a/src/server/utils/get-gql-pr-id.ts
+++ b/src/server/utils/get-gql-pr-id.ts
@@ -1,0 +1,31 @@
+import gql from 'graphql-tag';
+
+import {GraphQLPRIDQuery} from '../../types/gql-types';
+import {github} from '../../utils/github';
+
+export async function getPRID(
+    token: string, owner: string, name: string, num: number):
+    Promise<string|null> {
+  const results = await github().query<GraphQLPRIDQuery>({
+    query: graphqlPRId,
+    variables: {owner, name, num},
+    fetchPolicy: 'network-only',
+    context: {token}
+  });
+
+  if (!results.data.repository || !results.data.repository.pullRequest) {
+    return null;
+  }
+
+  return results.data.repository.pullRequest.id;
+}
+
+const graphqlPRId = gql`
+query GraphQLPRID($name: String!, $owner: String!, $num: Int!) {
+  repository(name:$name, owner: $owner) {
+    pullRequest(number: $num) {
+      id
+    }
+  }
+}
+`;

--- a/src/server/utils/get-pr-from-commit.ts
+++ b/src/server/utils/get-pr-from-commit.ts
@@ -5,7 +5,7 @@ import {github} from '../../utils/github';
 
 // Used to clean the data from Apollo / GitHub API
 export interface PullRequestDetails {
-  id: string;
+  gqlId: string;
   number: number;
   title: string;
   body: string;
@@ -76,7 +76,7 @@ export async function getPRDetailsFromCommit(
     // Should be safe based on:
     // https://stackoverflow.com/questions/9392365/how-would-git-handle-a-sha-1-collision-on-a-blob
     pr = {
-      id: prData.id,
+      gqlId: prData.id,
       number: prData.number,
       title: prData.title,
       body: prData.bodyText,

--- a/src/sw/sw.ts
+++ b/src/sw/sw.ts
@@ -1,7 +1,7 @@
 import {} from '.';
 declare var self: ServiceWorkerGlobalScope;
 
-import {NotificationPayload, NotificationURLData, SWClientMessage} from '../types/api';
+import {NotificationPayload, NotificationData, SWClientMessage} from '../types/api';
 import {Analytics} from './analytics';
 import {ClientIDModel} from '../client/public/scripts/models/client-id';
 
@@ -33,19 +33,89 @@ async function pingAnalytics(eventAction: string) {
 }
 
 type CustomNotification = {
-  data: NotificationURLData|void;
+  data: NotificationData|void; close: () => Promise<void>;
 };
 
 // This is displayed iff there is no data in the payload
 const DEFAULT_NOTIFICATION_OPTIONS: NotificationPayload = {
   title: 'New Github Health Updates',
   body: 'Click the notification to view updates',
+  icon: '/images/notification-images/icon-192x192.png',
+  badge: '/images/notification-images/badge-128x128.png',
   requireInteraction: false,
   data: {
     url: new URL('/', self.location.origin).toString(),
   },
   tag: 'default-notification',
 };
+
+async function cleanupNotifications(notifications: CustomNotification[]):
+    Promise<void> {
+  try {
+    // Using set to remove duplicates
+    const openPullRequests = new Set();
+    // This map allows us to link notifications to a specific PR
+    const prsToNotifications: {[key: string]: CustomNotification[]} = {};
+
+    for (let i = 0; i < notifications.length; i++) {
+      const notification: CustomNotification =
+          // tslint:disable-next-line:no-any
+          (notifications[i] as any) as CustomNotification;
+      if (!notification.data) {
+        continue;
+      }
+
+      const data: NotificationData = notification.data;
+      if (data.pullRequest) {
+        openPullRequests.add(data.pullRequest.gqlId);
+
+        if (!prsToNotifications[data.pullRequest.gqlId]) {
+          prsToNotifications[data.pullRequest.gqlId] = [];
+        }
+        prsToNotifications[data.pullRequest.gqlId].push(notification);
+      }
+    }
+
+    // Convert the set (used to remove duplicates) and create an array
+    // of PR's to check state of.
+    const pullRequestDetails = Array.from(openPullRequests);
+
+    // If there are no pull requests, don't bother making a network
+    // request.
+    if (pullRequestDetails.length === 0) {
+      return;
+    }
+
+    const response = await fetch('/api/check-pr-state', {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(pullRequestDetails),
+    });
+
+    if (!response.ok) {
+      console.warn('Unable to check PR states and clean up notifications');
+      console.warn(await response.text());
+      return;
+    }
+
+    const data = await response.json();
+    for (const pullRequest of data.pullRequests) {
+      if (pullRequest.state === 'CLOSED' || pullRequest.state === 'MERGED') {
+        const notifications = prsToNotifications[pullRequest.gqlId];
+
+        // Close all notifications for this PR.
+        for (const notification of notifications) {
+          await notification.close();
+        }
+      }
+    }
+  } catch (err) {
+    console.warn('Unable to clean up notifications: ', err);
+  }
+}
 
 async function getWindowClients(): Promise<WindowClient[]> {
   const clients = await self.clients.matchAll({
@@ -68,12 +138,20 @@ async function updateDashClients() {
 }
 
 async function showNotification(data: NotificationPayload) {
+  // First go through open notifications and collate the PR's
+  const previousNotifications = await self.registration.getNotifications();
+
   await self.registration.showNotification(
       data.title,
       data,
   );
 
-  await pingAnalytics('notification-shown');
+  await Promise.all([
+    pingAnalytics('notification-shown'),
+    cleanupNotifications(
+        // tslint:disable-next-line: no-any
+        (previousNotifications as any) as CustomNotification[]),
+  ]);
 }
 
 // This is an "EventListener"

--- a/src/test/server/controllers/webhook-events/status-test.ts
+++ b/src/test/server/controllers/webhook-events/status-test.ts
@@ -33,7 +33,7 @@ const FAKE_LOGIN_DETAILS = {
 };
 
 const PR_DETAILS: PullRequestDetails = {
-  id: 'test-pr-id',
+  gqlId: 'test-pr-id',
   number: 1,
   title: 'test-title',
   body: 'test-body',
@@ -474,6 +474,9 @@ test.serial(
             title: 'Automerge complete for \'test-title\'',
             body: '[status-test] test-title',
             data: {
+              pullRequest: {
+                gqlId: 'test-pr-id',
+              },
               url: 'http://test-url.com',
             },
             requireInteraction: false,
@@ -521,6 +524,9 @@ test.serial(
             title: 'Auto-merge failed: \'Injected Error\'',
             body: '[status-test] test-title',
             data: {
+              pullRequest: {
+                gqlId: 'test-pr-id',
+              },
               url: 'http://test-url.com',
             },
             requireInteraction: false,
@@ -572,6 +578,9 @@ test.serial(
             title: 'Auto-merge failed: \'Injected Error\'',
             body: '[status-test] test-title',
             data: {
+              pullRequest: {
+                gqlId: 'test-pr-id',
+              },
               url: 'http://test-url.com',
             },
             requireInteraction: false,
@@ -607,6 +616,9 @@ test.serial(
             title: 'test-description',
             body: '[status-test] test-title',
             data: {
+              pullRequest: {
+                gqlId: 'test-pr-id',
+              },
               url: 'http://test-url.com',
             },
             requireInteraction: false,
@@ -645,6 +657,9 @@ test.serial(
             title: 'test-description',
             body: '[status-test] test-title',
             data: {
+              pullRequest: {
+                gqlId: 'test-pr-id',
+              },
               url: 'http://test-url.com',
             },
             requireInteraction: false,

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -188,7 +188,7 @@ export interface NotificationPayload {
   title: string;
   body: string;
   requireInteraction: boolean;
-  data?: NotificationURLData;
+  data?: NotificationData;
   tag: string;
   icon?: string;
   badge?: string;
@@ -199,7 +199,15 @@ export interface ErrorPayload {
   message: string;
 }
 
-export interface NotificationURLData { url: string; }
+export interface NotificationPullRequestData {
+  gqlId: string;
+  state?: 'CLOSED'|'MERGED'|'OPEN';
+}
+
+export interface NotificationData {
+  url: string;
+  pullRequest?: NotificationPullRequestData;
+}
 
 export type SWClientMessage<T> = {
   action: 'push-received',
@@ -208,4 +216,8 @@ export type SWClientMessage<T> = {
 
 export type AutomergeOpts = {
   mergeType: 'manual'|'merge'|'squash'|'rebase',
+};
+
+export type CheckPRPayload = {
+  pullRequests: NotificationPullRequestData[],
 };

--- a/src/types/gql-types.ts
+++ b/src/types/gql-types.ts
@@ -1,6 +1,14 @@
 /* tslint:disable */
 //  This file was automatically generated and should not be edited.
 
+// The possible states of a pull request.
+export enum PullRequestState {
+  OPEN = "OPEN", // A pull request that is still open.
+  CLOSED = "CLOSED", // A pull request that has been closed without being merged.
+  MERGED = "MERGED", // A pull request that has been closed by being merged.
+}
+
+
 // The possible states of a pull request review.
 export enum PullRequestReviewState {
   PENDING = "PENDING", // A review that has not yet been submitted.
@@ -35,14 +43,6 @@ export enum StatusState {
   FAILURE = "FAILURE", // Status is failing.
   PENDING = "PENDING", // Status is pending.
   SUCCESS = "SUCCESS", // Status is successful.
-}
-
-
-// The possible states of a pull request.
-export enum PullRequestState {
-  OPEN = "OPEN", // A pull request that is still open.
-  CLOSED = "CLOSED", // A pull request that has been closed without being merged.
-  MERGED = "MERGED", // A pull request that has been closed by being merged.
 }
 
 
@@ -613,6 +613,177 @@ export interface StarsQuery {
   } | null,
 };
 
+export interface PRStateQueryVariables {
+  prIds: Array< string >,
+};
+
+export interface PRStateQuery {
+  // Lookup nodes by a list of IDs.
+  nodes:  Array<( {
+      __typename: "MarketplaceListing",
+    } | {
+      __typename: "Organization",
+    } | {
+      __typename: "Project",
+    } | {
+      __typename: "ProjectColumn",
+    } | {
+      __typename: "ProjectCard",
+    } | {
+      __typename: "Issue",
+    } | {
+      __typename: "User",
+    } | {
+      __typename: "Repository",
+    } | {
+      __typename: "CommitComment",
+    } | {
+      __typename: "UserContentEdit",
+    } | {
+      __typename: "Reaction",
+    } | {
+      __typename: "Commit",
+    } | {
+      __typename: "Status",
+    } | {
+      __typename: "StatusContext",
+    } | {
+      __typename: "Tree",
+    } | {
+      __typename: "Ref",
+    } | {
+      __typename: "PullRequest",
+      id: string,
+      // Identifies the state of the pull request.
+      state: PullRequestState,
+    } | {
+      __typename: "Label",
+    } | {
+      __typename: "IssueComment",
+    } | {
+      __typename: "PullRequestCommit",
+    } | {
+      __typename: "Milestone",
+    } | {
+      __typename: "ReviewRequest",
+    } | {
+      __typename: "Team",
+    } | {
+      __typename: "OrganizationInvitation",
+    } | {
+      __typename: "PullRequestReview",
+    } | {
+      __typename: "PullRequestReviewComment",
+    } | {
+      __typename: "CommitCommentThread",
+    } | {
+      __typename: "PullRequestReviewThread",
+    } | {
+      __typename: "ClosedEvent",
+    } | {
+      __typename: "ReopenedEvent",
+    } | {
+      __typename: "SubscribedEvent",
+    } | {
+      __typename: "UnsubscribedEvent",
+    } | {
+      __typename: "MergedEvent",
+    } | {
+      __typename: "ReferencedEvent",
+    } | {
+      __typename: "CrossReferencedEvent",
+    } | {
+      __typename: "AssignedEvent",
+    } | {
+      __typename: "UnassignedEvent",
+    } | {
+      __typename: "LabeledEvent",
+    } | {
+      __typename: "UnlabeledEvent",
+    } | {
+      __typename: "MilestonedEvent",
+    } | {
+      __typename: "DemilestonedEvent",
+    } | {
+      __typename: "RenamedTitleEvent",
+    } | {
+      __typename: "LockedEvent",
+    } | {
+      __typename: "UnlockedEvent",
+    } | {
+      __typename: "DeployedEvent",
+    } | {
+      __typename: "Deployment",
+    } | {
+      __typename: "DeploymentStatus",
+    } | {
+      __typename: "HeadRefDeletedEvent",
+    } | {
+      __typename: "HeadRefRestoredEvent",
+    } | {
+      __typename: "HeadRefForcePushedEvent",
+    } | {
+      __typename: "BaseRefForcePushedEvent",
+    } | {
+      __typename: "ReviewRequestedEvent",
+    } | {
+      __typename: "ReviewRequestRemovedEvent",
+    } | {
+      __typename: "ReviewDismissedEvent",
+    } | {
+      __typename: "DeployKey",
+    } | {
+      __typename: "Language",
+    } | {
+      __typename: "ProtectedBranch",
+    } | {
+      __typename: "PushAllowance",
+    } | {
+      __typename: "ReviewDismissalAllowance",
+    } | {
+      __typename: "Release",
+    } | {
+      __typename: "ReleaseAsset",
+    } | {
+      __typename: "RepositoryTopic",
+    } | {
+      __typename: "Topic",
+    } | {
+      __typename: "Gist",
+    } | {
+      __typename: "GistComment",
+    } | {
+      __typename: "PublicKey",
+    } | {
+      __typename: "OrganizationIdentityProvider",
+    } | {
+      __typename: "ExternalIdentity",
+    } | {
+      __typename: "Blob",
+    } | {
+      __typename: "Bot",
+    } | {
+      __typename: "BaseRefChangedEvent",
+    } | {
+      __typename: "AddedToProjectEvent",
+    } | {
+      __typename: "CommentDeletedEvent",
+    } | {
+      __typename: "ConvertedNoteToIssueEvent",
+    } | {
+      __typename: "MentionedEvent",
+    } | {
+      __typename: "MovedColumnsInProjectEvent",
+    } | {
+      __typename: "RemovedFromProjectEvent",
+    } | {
+      __typename: "RepositoryInvitation",
+    } | {
+      __typename: "Tag",
+    }
+  ) | null >,
+};
+
 export interface OutgoingPullRequestsQueryVariables {
   login: string,
   startCursor?: string | null,
@@ -1132,6 +1303,24 @@ export interface ViewerLoginQuery {
     // The user's public profile name.
     name: string | null,
   },
+};
+
+export interface GraphQLPRIDQueryVariables {
+  name: string,
+  owner: string,
+  num: number,
+};
+
+export interface GraphQLPRIDQuery {
+  // Lookup a given repository by the owner and repository name.
+  repository:  {
+    __typename: "Repository",
+    // Returns a single pull request from the current repository by number.
+    pullRequest:  {
+      __typename: "PullRequest",
+      id: string,
+    } | null,
+  } | null,
 };
 
 export interface CommitToPRQueryVariables {


### PR DESCRIPTION
This fixes #280

On a new push notification, if there are existing notifcations (which should rarely occur), a list of related pull requests are collected and check with backend for the current status of the PR. If any of the PR's are closed or merged, the notification is closed - removing stale notifications.

The plus-side of this is that turning on a new dormant machine should have reduced notifications.
The downside of this is that it will use up Github API quota :(