### PR TITLE
Status success notification

### DIFF
--- a/src/server/controllers/webhook-events/status.ts
+++ b/src/server/controllers/webhook-events/status.ts
@@ -62,6 +62,13 @@ async function handleSuccessStatus(
     return webhookResponse;
   }
 
+  if (prDetails.approvedReviewCount === 0) {
+    webhookResponse.message =
+        'Status of the PR\'s commit is \'SUCCESS\' but we have no approved ' +
+        'reviews';
+    return webhookResponse;
+  }
+
   const repo = hookData.repository;
 
   const automergeOpts = await pullRequestsModel.getAutomergeOpts(
@@ -72,8 +79,11 @@ async function handleSuccessStatus(
 
   if (!automergeOpts || !automergeOpts.mergeType ||
       automergeOpts.mergeType === 'manual') {
-    notificationTitle = 'PR is ready to merge';
-    webhookResponse.message = 'PR is ready to merge, automerge is not setup';
+    notificationTitle =
+        `Passing status checks & ${prDetails.approvedReviewCount} approval${
+            prDetails.approvedReviewCount > 1 ? 's' : ''}`;
+    webhookResponse.message =
+        'PR commit has success state, automerge is not setup';
   } else {
     try {
       await performAutomerge(

--- a/src/test/server/controllers/webhook-events/pull-request-review-test.ts
+++ b/src/test/server/controllers/webhook-events/pull-request-review-test.ts
@@ -73,7 +73,9 @@ function newFakePRDetails(extraDetails: {}) {
     commit: {
       oid: 'test-commit-SHA',
       state: 'PENDING',
-    }
+    },
+    reviews: [],
+    approvedReviewCount: 0,
   };
 
   return Object.assign({}, PR_DETAILS, extraDetails);

--- a/src/test/server/controllers/webhook-events/status-test.ts
+++ b/src/test/server/controllers/webhook-events/status-test.ts
@@ -24,7 +24,7 @@ const TEST_SECRETS = {
   PRIVATE_VAPID_KEY: 'o1P9aXm-QPZezF_8b7aQabivhv3QqaB0yg5zoFs6-qc',
 };
 
-const FAKE_LOGIN_DETAILS = {
+const FAKE_USER_RECORD = {
   githubToken: 'injected-fake-token',
   username: 'test-username',
   scopes: null,
@@ -169,7 +169,7 @@ test.serial(
     '[handleStatus]: should not handle success hook if no PR Details',
     async (t) => {
       t.context.sandbox.stub(userModel, 'getUserRecord').callsFake(() => {
-        return FAKE_LOGIN_DETAILS;
+        return FAKE_USER_RECORD;
       });
 
       const getPRDetailsStub =
@@ -196,7 +196,7 @@ test.serial(
     '[handleStatus]: should not handle error hook if no PR Details',
     async (t) => {
       t.context.sandbox.stub(userModel, 'getUserRecord').callsFake(() => {
-        return FAKE_LOGIN_DETAILS;
+        return FAKE_USER_RECORD;
       });
 
       const getPRDetailsStub =
@@ -223,7 +223,7 @@ test.serial(
     '[handleStatus]: should not handle success hook if PR is not open',
     async (t) => {
       t.context.sandbox.stub(userModel, 'getUserRecord').callsFake(() => {
-        return FAKE_LOGIN_DETAILS;
+        return FAKE_USER_RECORD;
       });
 
       t.context.sandbox.stub(getPRFromCommitModule, 'getPRDetailsFromCommit')
@@ -243,7 +243,7 @@ test.serial(
     '[handleStatus]: should not handle error hook if PR is not open',
     async (t) => {
       t.context.sandbox.stub(userModel, 'getUserRecord').callsFake(() => {
-        return FAKE_LOGIN_DETAILS;
+        return FAKE_USER_RECORD;
       });
 
       t.context.sandbox.stub(getPRFromCommitModule, 'getPRDetailsFromCommit')
@@ -263,7 +263,7 @@ test.serial(
     '[handleStatus]: should not handle success hook if the commit SHA is not the latest',
     async (t) => {
       t.context.sandbox.stub(userModel, 'getUserRecord').callsFake(() => {
-        return FAKE_LOGIN_DETAILS;
+        return FAKE_USER_RECORD;
       });
 
       t.context.sandbox.stub(getPRFromCommitModule, 'getPRDetailsFromCommit')
@@ -285,7 +285,7 @@ test.serial(
     '[handleStatus]: should not handle error hook if the commit SHA is not the latest',
     async (t) => {
       t.context.sandbox.stub(userModel, 'getUserRecord').callsFake(() => {
-        return FAKE_LOGIN_DETAILS;
+        return FAKE_USER_RECORD;
       });
 
       t.context.sandbox.stub(getPRFromCommitModule, 'getPRDetailsFromCommit')
@@ -305,7 +305,7 @@ test.serial(
 
 test.serial('[handleStatus]: should not handle pending hooks', async (t) => {
   t.context.sandbox.stub(userModel, 'getUserRecord').callsFake(() => {
-    return FAKE_LOGIN_DETAILS;
+    return FAKE_USER_RECORD;
   });
 
   t.context.sandbox.stub(getPRFromCommitModule, 'getPRDetailsFromCommit')
@@ -323,7 +323,7 @@ test.serial(
     '[handleStatus]: should handle success hook but not do anything if the commits state isn\'t success',
     async (t) => {
       t.context.sandbox.stub(userModel, 'getUserRecord').callsFake(() => {
-        return FAKE_LOGIN_DETAILS;
+        return FAKE_USER_RECORD;
       });
 
       t.context.sandbox.stub(getPRFromCommitModule, 'getPRDetailsFromCommit')
@@ -352,8 +352,8 @@ test.serial(
 test.serial(
     '[handleStatus]: should handle success hook but not do anything if there are no approved review',
     async (t) => {
-      t.context.sandbox.stub(userModel, 'getLoginDetails').callsFake(() => {
-        return FAKE_LOGIN_DETAILS;
+      t.context.sandbox.stub(userModel, 'getUserRecord').callsFake(() => {
+        return FAKE_USER_RECORD;
       });
 
       t.context.sandbox.stub(getPRFromCommitModule, 'getPRDetailsFromCommit')
@@ -385,7 +385,7 @@ test.serial(
     '[handleStatus]: should handle success hook but not automerge if its not configured for PR',
     async (t) => {
       t.context.sandbox.stub(userModel, 'getUserRecord').callsFake(() => {
-        return FAKE_LOGIN_DETAILS;
+        return FAKE_USER_RECORD;
       });
 
       t.context.sandbox.stub(getPRFromCommitModule, 'getPRDetailsFromCommit')
@@ -434,8 +434,8 @@ test.serial(
 test.serial(
     '[handleStatus]: should handle success hook but not automerge if its not configured for PR (with multiple reviews)',
     async (t) => {
-      t.context.sandbox.stub(userModel, 'getLoginDetails').callsFake(() => {
-        return FAKE_LOGIN_DETAILS;
+      t.context.sandbox.stub(userModel, 'getUserRecord').callsFake(() => {
+        return FAKE_USER_RECORD;
       });
 
       t.context.sandbox.stub(getPRFromCommitModule, 'getPRDetailsFromCommit')
@@ -485,7 +485,7 @@ test.serial(
     '[handleStatus]: should handle success hook but not automerge if mergeType is null',
     async (t) => {
       t.context.sandbox.stub(userModel, 'getUserRecord').callsFake(() => {
-        return FAKE_LOGIN_DETAILS;
+        return FAKE_USER_RECORD;
       });
 
       t.context.sandbox.stub(getPRFromCommitModule, 'getPRDetailsFromCommit')
@@ -537,7 +537,7 @@ test.serial(
     '[handleStatus]: should handle success hook but not automerge if mergeType is manual',
     async (t) => {
       t.context.sandbox.stub(userModel, 'getUserRecord').callsFake(() => {
-        return FAKE_LOGIN_DETAILS;
+        return FAKE_USER_RECORD;
       });
 
       t.context.sandbox.stub(getPRFromCommitModule, 'getPRDetailsFromCommit')
@@ -589,7 +589,7 @@ test.serial(
     '[handleStatus]: should handle success hook and notify users of successful automerge',
     async (t) => {
       t.context.sandbox.stub(userModel, 'getUserRecord').callsFake(() => {
-        return FAKE_LOGIN_DETAILS;
+        return FAKE_USER_RECORD;
       });
 
       t.context.sandbox.stub(getPRFromCommitModule, 'getPRDetailsFromCommit')
@@ -642,7 +642,7 @@ test.serial(
     '[handleStatus]: should handle success hook and notify users of an errored automerge *without* Githubs error response msg',
     async (t) => {
       t.context.sandbox.stub(userModel, 'getUserRecord').callsFake(() => {
-        return FAKE_LOGIN_DETAILS;
+        return FAKE_USER_RECORD;
       });
 
       t.context.sandbox.stub(getPRFromCommitModule, 'getPRDetailsFromCommit')
@@ -696,7 +696,7 @@ test.serial(
     '[handleStatus]: should handle success hook and notify users of an errored automerge using Githubs error response msg',
     async (t) => {
       t.context.sandbox.stub(userModel, 'getUserRecord').callsFake(() => {
-        return FAKE_LOGIN_DETAILS;
+        return FAKE_USER_RECORD;
       });
 
       t.context.sandbox.stub(getPRFromCommitModule, 'getPRDetailsFromCommit')
@@ -753,7 +753,7 @@ test.serial(
 test.serial(
     '[handleStatus]: should notify author for new error hook', async (t) => {
       t.context.sandbox.stub(userModel, 'getUserRecord').callsFake(() => {
-        return FAKE_LOGIN_DETAILS;
+        return FAKE_USER_RECORD;
       });
 
       t.context.sandbox.stub(getPRFromCommitModule, 'getPRDetailsFromCommit')
@@ -793,7 +793,7 @@ test.serial(
     '[handleStatus]: should notify author for error hook if new state is different from previous state',
     async (t) => {
       t.context.sandbox.stub(userModel, 'getUserRecord').callsFake(() => {
-        return FAKE_LOGIN_DETAILS;
+        return FAKE_USER_RECORD;
       });
 
       t.context.sandbox.stub(getPRFromCommitModule, 'getPRDetailsFromCommit')
@@ -835,7 +835,7 @@ test.serial(
     '[handleStatus]: should do nothing for error hook if the commits state is the same',
     async (t) => {
       t.context.sandbox.stub(userModel, 'getUserRecord').callsFake(() => {
-        return FAKE_LOGIN_DETAILS;
+        return FAKE_USER_RECORD;
       });
 
       t.context.sandbox.stub(getPRFromCommitModule, 'getPRDetailsFromCommit')

--- a/src/types/gql-types.ts
+++ b/src/types/gql-types.ts
@@ -1450,6 +1450,31 @@ export interface CommitToPRQuery {
             login: string,
           }
         ) | null,
+        // A list of reviews associated with the pull request.
+        reviews:  {
+          __typename: string,
+          // A list of nodes.
+          nodes:  Array< {
+            __typename: string,
+            // The actor who authored the comment.
+            author: ( {
+                __typename: "Organization",
+                // The username of the actor.
+                login: string,
+              } | {
+                __typename: "User",
+                // The username of the actor.
+                login: string,
+              } | {
+                __typename: "Bot",
+                // The username of the actor.
+                login: string,
+              }
+            ) | null,
+            // Identifies the current state of the pull request review.
+            state: PullRequestReviewState,
+          } | null > | null,
+        } | null,
         // A list of commits present in this pull request's head branch not present in the base branch.
         commits:  {
           __typename: string,


### PR DESCRIPTION
The current "Ready to merge" notifications are misleading, so I've altered the logic to not send a notification if there are no approvals and to soften the language to be more inline with the current update.