### PR TITLE
Adds hasNewActivity to API for pull requests

### DIFF
--- a/src/server/apis/dash-data/fetch-outgoing-data.ts
+++ b/src/server/apis/dash-data/fetch-outgoing-data.ts
@@ -4,7 +4,7 @@ import {commitFieldsFragment, OutgoingPullRequestsQuery, PullRequestReviewState,
 import {github} from '../../../utils/github';
 import {pullRequestsModel} from '../../models/pullRequestsModel';
 import {repositoryModel} from '../../models/repositoryModel';
-import {userModel, UserRecord} from '../../models/userModel';
+import {FeatureDetails, userModel, UserRecord} from '../../models/userModel';
 import {getPRLastActivityTimestamp} from '../../utils/get-pr-last-activity';
 import {issueHasNewActivity} from '../../utils/issue-has-new-activity';
 import {convertPrFields, convertReviewFields, outgoingPrsQuery} from '../dash-data';
@@ -79,8 +79,22 @@ async function getAllPRInfo(
   const prs: api.OutgoingPullRequest[] = [];
 
   if (data.user) {
-    const lastViewedInfo =
-        await userModel.getAllLastViewedInfo(userRecord.username);
+    const loginRecord = await userModel.getUserRecord(dashLogin);
+    let lastviewedFeature: FeatureDetails|null = null;
+    if (loginRecord) {
+      lastviewedFeature =
+          loginRecord.featureLastViewed ? loginRecord.featureLastViewed : null;
+    }
+
+    // Set up the feature usage *IF* the signed-in user is the viewed user.
+    if (!lastviewedFeature && dashLogin === userRecord.username) {
+      lastviewedFeature = {
+        enabledAt: Date.now(),
+      };
+      await userModel.setFeatureData(
+          userRecord.username, 'featureLastViewed', lastviewedFeature);
+    }
+    const lastViewedInfo = await userModel.getAllLastViewedInfo(dashLogin);
     const prConnection = data.user.pullRequests;
 
     // Set pagination info.
@@ -216,7 +230,7 @@ async function getAllPRInfo(
       const lastActivity = await getPRLastActivityTimestamp(fullPR);
       if (lastActivity) {
         fullPR.hasNewActivity = await issueHasNewActivity(
-            dashLogin, lastActivity, lastViewedInfo[pr.id]);
+            lastviewedFeature, lastActivity, lastViewedInfo[pr.id]);
       } else {
         fullPR.hasNewActivity = false;
       }

--- a/src/server/utils/get-pr-last-activity.ts
+++ b/src/server/utils/get-pr-last-activity.ts
@@ -1,0 +1,21 @@
+import {PullRequest} from '../../types/api';
+
+export function getPRLastActivityTimestamp(pr: PullRequest): number|null {
+  if (pr.events.length === 0) {
+    return null;
+  }
+  const lastEvent = pr.events[pr.events.length - 1];
+
+  let lastActivity = null;
+  if (lastEvent.type === 'OutgoingReviewEvent') {
+    lastActivity = lastEvent.reviews[lastEvent.reviews.length - 1].createdAt;
+  } else if (lastEvent.type === 'MyReviewEvent') {
+    lastActivity = lastEvent.review.createdAt;
+  } else if (lastEvent.type === 'NewCommitsEvent') {
+    lastActivity = lastEvent.lastPushedAt;
+  } else if (lastEvent.type === 'MentionedEvent') {
+    lastActivity = lastEvent.mentionedAt;
+  }
+
+  return lastActivity;
+}

--- a/src/server/utils/issue-has-new-activity.ts
+++ b/src/server/utils/issue-has-new-activity.ts
@@ -1,0 +1,27 @@
+import {userModel} from '../models/userModel';
+
+export async function issueHasNewActivity(
+    username: string, lastActivity: number, userLastViewed: number|null):
+    Promise<boolean> {
+  const userRecord = await userModel.getUserRecord(username);
+  if (!userRecord) {
+    return false;
+  }
+
+  let lastviewedFeature = userRecord.featureLastViewed;
+  if (!lastviewedFeature) {
+    lastviewedFeature = {
+      enabledAt: Date.now(),
+    };
+    await userModel.setFeatureData(
+        username, 'featureLastViewed', lastviewedFeature);
+  }
+
+  // We need to account for when the feature was first used and when
+  // the user last interacted with the issue
+  if (!userLastViewed || userLastViewed < lastviewedFeature.enabledAt) {
+    userLastViewed = lastviewedFeature.enabledAt;
+  }
+
+  return (lastActivity > userLastViewed);
+}

--- a/src/server/utils/issue-has-new-activity.ts
+++ b/src/server/utils/issue-has-new-activity.ts
@@ -1,27 +1,18 @@
-import {userModel} from '../models/userModel';
+import {FeatureDetails} from '../models/userModel';
 
 export async function issueHasNewActivity(
-    username: string, lastActivity: number, userLastViewed: number|null):
-    Promise<boolean> {
-  const userRecord = await userModel.getUserRecord(username);
-  if (!userRecord) {
+    featureLastViewed: FeatureDetails|null,
+    lastActivity: number,
+    userLastViewed: number|null): Promise<boolean> {
+  if (!featureLastViewed) {
     return false;
-  }
-
-  let lastviewedFeature = userRecord.featureLastViewed;
-  if (!lastviewedFeature) {
-    lastviewedFeature = {
-      enabledAt: Date.now(),
-    };
-    await userModel.setFeatureData(
-        username, 'featureLastViewed', lastviewedFeature);
   }
 
   // We need to account for when the feature was first used and when
   // the user last interacted with the issue
-  if (!userLastViewed || userLastViewed < lastviewedFeature.enabledAt) {
-    userLastViewed = lastviewedFeature.enabledAt;
+  if (!userLastViewed || userLastViewed < featureLastViewed.enabledAt) {
+    userLastViewed = featureLastViewed.enabledAt;
   }
 
-  return (lastActivity > userLastViewed);
+  return lastActivity > userLastViewed;
 }

--- a/src/test/server/apis/incoming-prs-test.ts
+++ b/src/test/server/apis/incoming-prs-test.ts
@@ -2,6 +2,7 @@ import anyTest, {TestInterface} from 'ava';
 
 import {startTestReplayServer} from '../../../replay-server';
 import {fetchIncomingData} from '../../../server/apis/dash-data';
+import {UserRecord} from '../../../server/models/userModel';
 import {IncomingDashResponse, PullRequest} from '../../../types/api';
 import {PullRequestReviewState} from '../../../types/gql-types';
 import {initFirestore} from '../../../utils/firestore';
@@ -26,8 +27,15 @@ test.beforeEach(async (t) => {
       await startTestReplayServer(t, 'project-health1-dashboard incoming');
   initGithub(url, url);
 
-  const data = await fetchIncomingData(
-      'project-health1', getTestTokens()['project-health1']);
+  const userRecord: UserRecord = {
+    username: 'project-health1',
+    githubToken: getTestTokens()['project-health1'],
+    scopes: [],
+    fullname: '',
+    avatarUrl: '',
+    lastKnownUpdate: '',
+  };
+  const data = await fetchIncomingData(userRecord, 'project-health1');
   server.close();
 
   const prsById = new Map();

--- a/src/test/server/apis/incoming-prs-test.ts
+++ b/src/test/server/apis/incoming-prs-test.ts
@@ -4,6 +4,7 @@ import {startTestReplayServer} from '../../../replay-server';
 import {fetchIncomingData} from '../../../server/apis/dash-data';
 import {IncomingDashResponse, PullRequest} from '../../../types/api';
 import {PullRequestReviewState} from '../../../types/gql-types';
+import {initFirestore} from '../../../utils/firestore';
 import {initGithub} from '../../../utils/github';
 import {getTestTokens} from '../../get-test-tokens';
 
@@ -12,6 +13,10 @@ type TestContext = {
   prsById: Map<string, PullRequest>,
 };
 const test = anyTest as TestInterface<TestContext>;
+
+test.before(() => {
+  initFirestore();
+});
 
 /**
  * Generates the test context object before each test.
@@ -37,13 +42,13 @@ test.beforeEach(async (t) => {
   };
 });
 
-test('dashincoming: sane output', (t) => {
+test('[incoming-prs-test]: sane output', (t) => {
   const data = t.context.data;
   // Make sure a test is added each time these numbers are changed.
   t.is(data.prs.length, 7);
 });
 
-test('dashincoming: events are always sorted correctly', (t) => {
+test('[incoming-prs-test]: events are always sorted correctly', (t) => {
   const data = t.context.data;
   for (const pr of data.prs) {
     let lastTime = 0;
@@ -63,7 +68,7 @@ test('dashincoming: events are always sorted correctly', (t) => {
   }
 });
 
-test('dashincoming: incoming PRs are ordered', (t) => {
+test('[incoming-prs-test]: incoming PRs are ordered', (t) => {
   const prs = t.context.data.prs;
 
   // Actionable status items appear before non actionable ones.
@@ -138,34 +143,37 @@ test('dashincoming: incoming PRs are ordered', (t) => {
   }
 });
 
-test('dashincoming: Incoming PR with old @mention before I reviewed', (t) => {
-  t.deepEqual(t.context.prsById.get('11'), {
-    id: 'MDExOlB1bGxSZXF1ZXN0MTY3ODI2Mzk1',
-    author: 'project-health2',
-    avatarUrl: 'https://avatars3.githubusercontent.com/u/34584974?v=4',
-    createdAt: 1518042329000,
-    events: [
-      {
-        review: {
-          author: 'project-health1',
-          createdAt: 1518042373000,
-          reviewState: PullRequestReviewState.COMMENTED,
+test(
+    '[incoming-prs-test]: Incoming PR with old @mention before I reviewed',
+    (t) => {
+      t.deepEqual(t.context.prsById.get('11'), {
+        id: 'MDExOlB1bGxSZXF1ZXN0MTY3ODI2Mzk1',
+        author: 'project-health2',
+        avatarUrl: 'https://avatars3.githubusercontent.com/u/34584974?v=4',
+        createdAt: 1518042329000,
+        events: [
+          {
+            review: {
+              author: 'project-health1',
+              createdAt: 1518042373000,
+              reviewState: PullRequestReviewState.COMMENTED,
+            },
+            type: 'MyReviewEvent',
+          },
+        ],
+        number: 11,
+        owner: 'project-health1',
+        repo: 'repo',
+        status: {
+          type: 'ApprovalRequired',
         },
-        type: 'MyReviewEvent',
-      },
-    ],
-    number: 11,
-    owner: 'project-health1',
-    repo: 'repo',
-    status: {
-      type: 'ApprovalRequired',
-    },
-    title: 'A new pull request',
-    url: 'https://github.com/project-health1/repo/pull/11',
-  });
-});
+        title: 'A new pull request',
+        url: 'https://github.com/project-health1/repo/pull/11',
+        hasNewActivity: false,
+      });
+    });
 
-test('dashincoming: Incoming PR with new @mention after I reviewed', (t) => {
+test('[incoming-prs-test]: Incoming PR with new @mention after I reviewed', (t) => {
   t.deepEqual(t.context.prsById.get('10'), {
     id: 'MDExOlB1bGxSZXF1ZXN0MTY3Nzg1NjAw',
     author: 'project-health2',
@@ -196,10 +204,11 @@ test('dashincoming: Incoming PR with new @mention after I reviewed', (t) => {
     },
     title: 'Questionable changes',
     url: 'https://github.com/project-health1/repo/pull/10',
+    hasNewActivity: false,
   });
 });
 
-test('dashincoming: Incoming PR that I reviewed. New commit since', (t) => {
+test('[incoming-prs-test]: Incoming PR that I reviewed. New commit since', (t) => {
   t.deepEqual(t.context.prsById.get('9'), {
     id: 'MDExOlB1bGxSZXF1ZXN0MTY2MzUxNTky',
     author: 'project-health2',
@@ -233,10 +242,11 @@ test('dashincoming: Incoming PR that I reviewed. New commit since', (t) => {
     },
     title: 'Update links in readme',
     url: 'https://github.com/project-health1/repo/pull/9',
+    hasNewActivity: false,
   });
 });
 
-test('dashincoming: Incoming PR, I requested changes', (t) => {
+test('[incoming-prs-test]: Incoming PR, I requested changes', (t) => {
   t.deepEqual(t.context.prsById.get('3'), {
     id: 'MDExOlB1bGxSZXF1ZXN0MTY0NzE5MzU4',
     author: 'project-health2',
@@ -256,10 +266,11 @@ test('dashincoming: Incoming PR, I requested changes', (t) => {
         reviewState: PullRequestReviewState.CHANGES_REQUESTED,
       }
     }],
+    hasNewActivity: false,
   });
 });
 
-test('dashincoming: Incoming review request', (t) => {
+test('[incoming-prs-test]: Incoming review request', (t) => {
   t.deepEqual(t.context.prsById.get('4'), {
     id: 'MDExOlB1bGxSZXF1ZXN0MTY0NzI1NzUw',
     author: 'project-health2',
@@ -272,10 +283,11 @@ test('dashincoming: Incoming review request', (t) => {
     url: 'https://github.com/project-health1/repo/pull/4',
     status: {type: 'ReviewRequired'},
     events: [],
+    hasNewActivity: false,
   });
 });
 
-test('dashincoming: incoming with mention, new commits', (t) => {
+test('[incoming-prs-test]: incoming with mention, new commits', (t) => {
   t.deepEqual(t.context.prsById.get('13'), {
     id: 'MDExOlB1bGxSZXF1ZXN0MTczNjExNzIw',
     author: 'project-health2',
@@ -314,10 +326,11 @@ test('dashincoming: incoming with mention, new commits', (t) => {
             'https://github.com/project-health1/repo/pull/13#issuecomment-371333354',
       },
     ],
+    hasNewActivity: false,
   });
 });
 
-test('dashincoming: Incoming PR with changes requested', (t) => {
+test('[incoming-prs-test]: Incoming PR with changes requested', (t) => {
   t.deepEqual(t.context.prsById.get('14'), {
     id: 'MDExOlB1bGxSZXF1ZXN0MTc0NDY2NTk5',
     author: 'project-health2',
@@ -341,5 +354,6 @@ test('dashincoming: Incoming PR with changes requested', (t) => {
     },
     title: 'Modify readme description',
     url: 'https://github.com/project-health1/repo/pull/14',
+    hasNewActivity: false,
   });
 });

--- a/src/test/server/apis/outgoing-prs-2-test.ts
+++ b/src/test/server/apis/outgoing-prs-2-test.ts
@@ -97,6 +97,7 @@ test('dashoutgoing2: requested changes', (t) => {
     },
     title: 'Modify readme description',
     url: 'https://github.com/project-health1/repo/pull/14',
+    hasNewActivity: false,
   });
 });
 
@@ -135,6 +136,7 @@ test('dashoutgoing2: review with comments', (t) => {
     },
     title: 'My changes to readme',
     url: 'https://github.com/project-health1/repo/pull/13',
+    hasNewActivity: false,
   });
 });
 
@@ -173,6 +175,7 @@ test('dashoutgoing2: review with comments2', (t) => {
     },
     title: 'A new pull request',
     url: 'https://github.com/project-health1/repo/pull/11',
+    hasNewActivity: false,
   });
 });
 
@@ -208,6 +211,7 @@ test('dashoutgoing2: ready to merge', (t) => {
     },
     title: 'Questionable changes',
     url: 'https://github.com/project-health1/repo/pull/10',
+    hasNewActivity: false,
   });
 });
 
@@ -244,6 +248,7 @@ test('dashoutgoing2: changes requested, new commit', (t) => {
     },
     title: 'Update links in readme',
     url: 'https://github.com/project-health1/repo/pull/9',
+    hasNewActivity: false,
   });
 });
 
@@ -271,6 +276,7 @@ test('dashoutgoing2: no review', (t) => {
     },
     title: 'Add a field for getting the template of an element',
     url: 'https://github.com/project-health1/repo/pull/4',
+    hasNewActivity: false,
   });
 });
 
@@ -306,5 +312,6 @@ test('dashoutgoing2: basic requested changes', (t) => {
     },
     title: 'A couple minor changes for browserify compatibility',
     url: 'https://github.com/project-health1/repo/pull/3',
+    hasNewActivity: false,
   });
 });

--- a/src/test/server/apis/outgoing-prs-test.ts
+++ b/src/test/server/apis/outgoing-prs-test.ts
@@ -56,13 +56,13 @@ test.before(async (t) => {
   };
 });
 
-test('dashoutgoing: sane output', (t) => {
+test('[outgoing-prs-test]: sane output', (t) => {
   const data = t.context.data;
   // Make sure a test is added each time these numbers are changed.
   t.is(data.prs.length, 11);
 });
 
-test('dashoutgoing: outgoing PRs are sorted', (t) => {
+test('[outgoing-prs-test]: outgoing PRs are sorted', (t) => {
   const data = t.context.data;
   let lastCreatedAt = data.prs[0].createdAt;
   for (const pr of data.prs) {
@@ -71,7 +71,7 @@ test('dashoutgoing: outgoing PRs are sorted', (t) => {
   }
 });
 
-test('dashoutgoing: outgoing PR, review with my own replies', (t) => {
+test('[outgoing-prs-test]: outgoing PR, review with my own replies', (t) => {
   t.deepEqual(t.context.prsById.get('project-health1/repo/pull/8'), {
     id: 'MDExOlB1bGxSZXF1ZXN0MTY2MTM2ODI5',
     author: 'project-health1',
@@ -104,10 +104,11 @@ test('dashoutgoing: outgoing PR, review with my own replies', (t) => {
     mergeable: MergeableState.MERGEABLE,
     automergeOpts: null,
     automergeAvailable: false,
+    hasNewActivity: false,
   });
 });
 
-test('dashoutgoing: Outgoing PR, no reviewers', (t) => {
+test('[outgoing-prs-test]: Outgoing PR, no reviewers', (t) => {
   t.deepEqual(t.context.prsById.get('project-health1/repo/pull/7'), {
     id: 'MDExOlB1bGxSZXF1ZXN0MTY2MTIxMzYx',
     author: 'project-health1',
@@ -130,10 +131,11 @@ test('dashoutgoing: Outgoing PR, no reviewers', (t) => {
     mergeable: MergeableState.MERGEABLE,
     automergeOpts: null,
     automergeAvailable: false,
+    hasNewActivity: false,
   });
 });
 
-test('dashoutgoing: Outgoing PR, changes requested', (t) => {
+test('[outgoing-prs-test]: Outgoing PR, changes requested', (t) => {
   t.deepEqual(t.context.prsById.get('project-health1/repo/pull/6'), {
     id: 'MDExOlB1bGxSZXF1ZXN0MTY1NzkzODg3',
     author: 'project-health1',
@@ -161,10 +163,11 @@ test('dashoutgoing: Outgoing PR, changes requested', (t) => {
     mergeable: MergeableState.MERGEABLE,
     automergeOpts: null,
     automergeAvailable: false,
+    hasNewActivity: false,
   });
 });
 
-test('dashoutgoing: Outgoing PR, approved, ready to merge', (t) => {
+test('[outgoing-prs-test]: Outgoing PR, approved, ready to merge', (t) => {
   t.deepEqual(t.context.prsById.get('project-health1/repo/pull/5'), {
     id: 'MDExOlB1bGxSZXF1ZXN0MTY1NzkzNDcx',
     author: 'project-health1',
@@ -192,10 +195,11 @@ test('dashoutgoing: Outgoing PR, approved, ready to merge', (t) => {
     mergeable: MergeableState.MERGEABLE,
     automergeOpts: null,
     automergeAvailable: false,
+    hasNewActivity: false,
   });
 });
 
-test('dashoutgoing: Outgoing PR, has 1 commented review', (t) => {
+test('[outgoing-prs-test]: Outgoing PR, has 1 commented review', (t) => {
   t.deepEqual(t.context.prsById.get('project-health1/repo/pull/2'), {
     id: 'MDExOlB1bGxSZXF1ZXN0MTYzODY0NTkz',
     author: 'project-health1',
@@ -225,10 +229,11 @@ test('dashoutgoing: Outgoing PR, has 1 commented review', (t) => {
     mergeable: MergeableState.MERGEABLE,
     automergeOpts: null,
     automergeAvailable: false,
+    hasNewActivity: false,
   });
 });
 
-test('dashoutgoing: Outgoing PR, requested reviews, no reviews', (t) => {
+test('[outgoing-prs-test]: Outgoing PR, requested reviews, no reviews', (t) => {
   t.deepEqual(t.context.prsById.get('project-health1/repo/pull/1'), {
     id: 'MDExOlB1bGxSZXF1ZXN0MTU4Njg4ODg0',
     author: 'project-health1',
@@ -249,11 +254,12 @@ test('dashoutgoing: Outgoing PR, requested reviews, no reviews', (t) => {
     mergeable: MergeableState.MERGEABLE,
     automergeOpts: null,
     automergeAvailable: false,
+    hasNewActivity: false,
   });
 });
 
 
-test('dashoutgoing: review requested changes then approved', (t) => {
+test('[outgoing-prs-test]: review requested changes then approved', (t) => {
   t.deepEqual(t.context.prsById.get('project-health1/repo/pull/12'), {
     id: 'MDExOlB1bGxSZXF1ZXN0MTcyMTEzODAz',
     author: 'project-health1',
@@ -281,10 +287,11 @@ test('dashoutgoing: review requested changes then approved', (t) => {
     mergeable: MergeableState.MERGEABLE,
     automergeOpts: null,
     automergeAvailable: false,
+    hasNewActivity: false,
   });
 });
 
-test('dashoutgoing: with success status', (t) => {
+test('[outgoing-prs-test]: with success status', (t) => {
   t.deepEqual(t.context.prsById.get('project-health1/status-repo/pull/3'), {
     id: 'MDExOlB1bGxSZXF1ZXN0MTc0NDQ3NDAw',
     author: 'project-health1',
@@ -312,10 +319,11 @@ test('dashoutgoing: with success status', (t) => {
     mergeable: MergeableState.UNKNOWN,
     automergeOpts: null,
     automergeAvailable: false,
+    hasNewActivity: false,
   });
 });
 
-test('dashoutgoing: with pending status', (t) => {
+test('[outgoing-prs-test]: with pending status', (t) => {
   t.deepEqual(t.context.prsById.get('project-health1/status-repo/pull/4'), {
     id: 'MDExOlB1bGxSZXF1ZXN0MTc0NDQ3NDYz',
     author: 'project-health1',
@@ -343,10 +351,11 @@ test('dashoutgoing: with pending status', (t) => {
     mergeable: MergeableState.UNKNOWN,
     automergeOpts: null,
     automergeAvailable: false,
+    hasNewActivity: false,
   });
 });
 
-test('dashoutgoing: with error status', (t) => {
+test('[outgoing-prs-test]: with error status', (t) => {
   t.deepEqual(t.context.prsById.get('project-health1/status-repo/pull/5'), {
     id: 'MDExOlB1bGxSZXF1ZXN0MTc0NDQ3NTc1',
     author: 'project-health1',
@@ -374,10 +383,11 @@ test('dashoutgoing: with error status', (t) => {
     mergeable: MergeableState.UNKNOWN,
     automergeOpts: null,
     automergeAvailable: false,
+    hasNewActivity: false,
   });
 });
 
-test('dashoutgoing: with failing status', (t) => {
+test('[outgoing-prs-test]: with failing status', (t) => {
   t.deepEqual(t.context.prsById.get('project-health1/status-repo/pull/6'), {
     id: 'MDExOlB1bGxSZXF1ZXN0MTc0NDQ3Njk2',
     author: 'project-health1',
@@ -405,5 +415,6 @@ test('dashoutgoing: with failing status', (t) => {
     mergeable: MergeableState.UNKNOWN,
     automergeOpts: null,
     automergeAvailable: false,
+    hasNewActivity: false,
   });
 });

--- a/src/test/server/models/userModel-test.ts
+++ b/src/test/server/models/userModel-test.ts
@@ -296,27 +296,26 @@ test.serial('[usermodel]: should set and last viewed feature', async (t) => {
       .doc(TEST_USERNAME)
       .set(exampleData);
 
-  await userModel.setFeatureData(TEST_USERNAME, 'feature-lastViewed', {
+  await userModel.setFeatureData(TEST_USERNAME, 'featureLastViewed', {
     enabledAt: 1,
   });
   const userRecord = await userModel.getUserRecord(TEST_USERNAME);
   if (!userRecord) {
     throw new Error('Expected user record to exist.');
   }
-  t.deepEqual(userRecord['feature-lastViewed'], {
+  t.deepEqual(userRecord['featureLastViewed'], {
     enabledAt: 1,
   });
 });
 
 test.serial(
-    '[usermodel]: should throw when setting a feature for a non existent user',
+    '[usermodel]: should not throw when setting a feature for a non existent user',
     async (t) => {
-      await t.throws(async () => {
-        await userModel.setFeatureData(
-            'non-existent-user', 'feature-lastViewed', {
-              enabledAt: 1,
-            });
+      await userModel.setFeatureData('non-existent-user', 'featureLastViewed', {
+        enabledAt: 1,
       });
+
+      t.pass();
     });
 
 test.serial('[usermodel]: should mark user for update', async (t) => {
@@ -346,14 +345,9 @@ test.serial(
 
 test.serial(
     '[usermodel]: should set and get last viewed timestamp', async (t) => {
-      let value =
-          await userModel.getIssueLastViewed('example-user', 'test-issue-id');
-      t.deepEqual(value, null);
+      let value = await userModel.getAllLastViewedInfo('example-user');
+      t.deepEqual(value, {});
       await userModel.updateLastViewed('example-user', 'test-issue-id', 1);
-      value =
-          await userModel.getIssueLastViewed('example-user', 'test-issue-id');
-      t.deepEqual(value, 1);
-      value =
-          await userModel.getIssueLastViewed('example-user', 'test-issue-id-2');
-      t.deepEqual(value, null);
+      value = await userModel.getAllLastViewedInfo('example-user');
+      t.deepEqual(value['test-issue-id'], 1);
     });

--- a/src/test/server/util/issue-has-new-activity-test.ts
+++ b/src/test/server/util/issue-has-new-activity-test.ts
@@ -1,0 +1,152 @@
+import anyTest, {TestInterface} from 'ava';
+import * as sinon from 'sinon';
+import {SinonSandbox} from 'sinon';
+
+import {userModel, UserRecord} from '../../../server/models/userModel';
+import {issueHasNewActivity} from '../../../server/utils/issue-has-new-activity';
+import {initFirestore} from '../../../utils/firestore';
+
+type TestContext = {
+  sandbox: SinonSandbox,
+};
+const test = anyTest as TestInterface<TestContext>;
+
+test.before(() => {
+  initFirestore();
+});
+
+test.beforeEach(async (t) => {
+  t.context = {
+    sandbox: sinon.sandbox.create(),
+  };
+});
+
+test.afterEach((t) => {
+  t.context.sandbox.restore();
+});
+
+test.serial(
+    '[issueHasNewActivity]: should return false when no user record',
+    async (t) => {
+      const activity = await issueHasNewActivity('example-username', 0, 1);
+      t.deepEqual(activity, false, 'issue has activity');
+    });
+
+test.serial(
+    '[issueHasNewActivity]: should set last used feature when its undefined',
+    async (t) => {
+      t.context.sandbox.stub(userModel, 'getUserRecord').callsFake(() => {
+        const fakeRecord: UserRecord = {
+          githubToken: 'test-token',
+          scopes: [],
+          username: '',
+          fullname: '',
+          avatarUrl: '',
+          lastKnownUpdate: '',
+        };
+        return fakeRecord;
+      });
+      const setFeatureSpy = t.context.sandbox.spy(userModel, 'setFeatureData');
+
+      const activity = await issueHasNewActivity('example-username', 0, null);
+      t.deepEqual(activity, false, 'issue has activity');
+      t.deepEqual(setFeatureSpy.callCount, 1, 'setFeature should be called');
+      t.deepEqual(
+          setFeatureSpy.args[0][0],
+          'example-username',
+          'setFeature called for username');
+      t.deepEqual(
+          setFeatureSpy.args[0][1], 'featureLastViewed', 'Expected feature ID');
+      t.truthy(setFeatureSpy.args[0][2]);
+      t.truthy(setFeatureSpy.args[0][2].enabledAt);
+    });
+
+test.serial(
+    '[issueHasNewActivity]: should not set last used feature when its defined',
+    async (t) => {
+      t.context.sandbox.stub(userModel, 'getUserRecord').callsFake(() => {
+        const fakeRecord: UserRecord = {
+          githubToken: 'test-token',
+          scopes: [],
+          username: '',
+          fullname: '',
+          avatarUrl: '',
+          lastKnownUpdate: '',
+          featureLastViewed: {
+            enabledAt: 1,
+          }
+        };
+        return fakeRecord;
+      });
+      const setFeatureSpy = t.context.sandbox.spy(userModel, 'setFeatureData');
+
+      const activity = await issueHasNewActivity('example-username', 0, null);
+      t.deepEqual(activity, false, 'issue has activity');
+      t.deepEqual(setFeatureSpy.callCount, 0, 'setFeature should be called');
+    });
+
+test.serial(
+    '[issueHasNewActivity]: should use feature enabled at instead of user last viewed',
+    async (t) => {
+      t.context.sandbox.stub(userModel, 'getUserRecord').callsFake(() => {
+        const fakeRecord: UserRecord = {
+          githubToken: 'test-token',
+          scopes: [],
+          username: '',
+          fullname: '',
+          avatarUrl: '',
+          lastKnownUpdate: '',
+          featureLastViewed: {
+            enabledAt: 2,
+          }
+        };
+        return fakeRecord;
+      });
+
+      const activity = await issueHasNewActivity('example-username', 1, 0);
+      t.deepEqual(activity, false, 'issue has activity');
+    });
+
+test.serial(
+    '[issueHasNewActivity]: should use last viewed if more recent than feature enabled',
+    async (t) => {
+      t.context.sandbox.stub(userModel, 'getUserRecord').callsFake(() => {
+        const fakeRecord: UserRecord = {
+          githubToken: 'test-token',
+          scopes: [],
+          username: '',
+          fullname: '',
+          avatarUrl: '',
+          lastKnownUpdate: '',
+          featureLastViewed: {
+            enabledAt: 0,
+          }
+        };
+        return fakeRecord;
+      });
+
+      const activity = await issueHasNewActivity('example-username', 1, 2);
+      t.deepEqual(activity, false, 'issue has activity');
+    });
+
+test.serial(
+    '[issueHasNewActivity]: should mark as new entry when its timestamp is great than last viewed',
+    async (t) => {
+      t.context.sandbox.stub(userModel, 'getUserRecord').callsFake(() => {
+        const fakeRecord: UserRecord = {
+          githubToken: 'test-token',
+          scopes: [],
+          username: '',
+          fullname: '',
+          avatarUrl: '',
+          lastKnownUpdate: '',
+          featureLastViewed: {
+            enabledAt: 0,
+          }
+        };
+        return fakeRecord;
+      });
+
+      const activity = await issueHasNewActivity('example-username', 2, 1);
+      t.deepEqual(activity, true, 'issue has activity');
+    });

--- a/src/test/server/util/issue-has-new-activity-test.ts
+++ b/src/test/server/util/issue-has-new-activity-test.ts
@@ -2,7 +2,7 @@ import anyTest, {TestInterface} from 'ava';
 import * as sinon from 'sinon';
 import {SinonSandbox} from 'sinon';
 
-import {userModel, UserRecord} from '../../../server/models/userModel';
+import {FeatureDetails} from '../../../server/models/userModel';
 import {issueHasNewActivity} from '../../../server/utils/issue-has-new-activity';
 import {initFirestore} from '../../../utils/firestore';
 
@@ -26,127 +26,39 @@ test.afterEach((t) => {
 });
 
 test.serial(
-    '[issueHasNewActivity]: should return false when no user record',
-    async (t) => {
-      const activity = await issueHasNewActivity('example-username', 0, 1);
+    '[issueHasNewActivity]: should handle no feature details', async (t) => {
+      const activity = await issueHasNewActivity(null, 0, null);
       t.deepEqual(activity, false, 'issue has activity');
-    });
-
-test.serial(
-    '[issueHasNewActivity]: should set last used feature when its undefined',
-    async (t) => {
-      t.context.sandbox.stub(userModel, 'getUserRecord').callsFake(() => {
-        const fakeRecord: UserRecord = {
-          githubToken: 'test-token',
-          scopes: [],
-          username: '',
-          fullname: '',
-          avatarUrl: '',
-          lastKnownUpdate: '',
-        };
-        return fakeRecord;
-      });
-      const setFeatureSpy = t.context.sandbox.spy(userModel, 'setFeatureData');
-
-      const activity = await issueHasNewActivity('example-username', 0, null);
-      t.deepEqual(activity, false, 'issue has activity');
-      t.deepEqual(setFeatureSpy.callCount, 1, 'setFeature should be called');
-      t.deepEqual(
-          setFeatureSpy.args[0][0],
-          'example-username',
-          'setFeature called for username');
-      t.deepEqual(
-          setFeatureSpy.args[0][1], 'featureLastViewed', 'Expected feature ID');
-      t.truthy(setFeatureSpy.args[0][2]);
-      t.truthy(setFeatureSpy.args[0][2].enabledAt);
-    });
-
-test.serial(
-    '[issueHasNewActivity]: should not set last used feature when its defined',
-    async (t) => {
-      t.context.sandbox.stub(userModel, 'getUserRecord').callsFake(() => {
-        const fakeRecord: UserRecord = {
-          githubToken: 'test-token',
-          scopes: [],
-          username: '',
-          fullname: '',
-          avatarUrl: '',
-          lastKnownUpdate: '',
-          featureLastViewed: {
-            enabledAt: 1,
-          }
-        };
-        return fakeRecord;
-      });
-      const setFeatureSpy = t.context.sandbox.spy(userModel, 'setFeatureData');
-
-      const activity = await issueHasNewActivity('example-username', 0, null);
-      t.deepEqual(activity, false, 'issue has activity');
-      t.deepEqual(setFeatureSpy.callCount, 0, 'setFeature should be called');
     });
 
 test.serial(
     '[issueHasNewActivity]: should use feature enabled at instead of user last viewed',
     async (t) => {
-      t.context.sandbox.stub(userModel, 'getUserRecord').callsFake(() => {
-        const fakeRecord: UserRecord = {
-          githubToken: 'test-token',
-          scopes: [],
-          username: '',
-          fullname: '',
-          avatarUrl: '',
-          lastKnownUpdate: '',
-          featureLastViewed: {
-            enabledAt: 2,
-          }
-        };
-        return fakeRecord;
-      });
+      const fakeDetails = {
+        enabledAt: 2,
+      };
 
-      const activity = await issueHasNewActivity('example-username', 1, 0);
+      const activity = await issueHasNewActivity(fakeDetails, 1, 0);
       t.deepEqual(activity, false, 'issue has activity');
     });
 
 test.serial(
     '[issueHasNewActivity]: should use last viewed if more recent than feature enabled',
     async (t) => {
-      t.context.sandbox.stub(userModel, 'getUserRecord').callsFake(() => {
-        const fakeRecord: UserRecord = {
-          githubToken: 'test-token',
-          scopes: [],
-          username: '',
-          fullname: '',
-          avatarUrl: '',
-          lastKnownUpdate: '',
-          featureLastViewed: {
-            enabledAt: 0,
-          }
-        };
-        return fakeRecord;
-      });
+      const fakeDetails: FeatureDetails = {
+        enabledAt: 0,
+      };
 
-      const activity = await issueHasNewActivity('example-username', 1, 2);
+      const activity = await issueHasNewActivity(fakeDetails, 1, 2);
       t.deepEqual(activity, false, 'issue has activity');
     });
 
 test.serial(
     '[issueHasNewActivity]: should mark as new entry when its timestamp is great than last viewed',
     async (t) => {
-      t.context.sandbox.stub(userModel, 'getUserRecord').callsFake(() => {
-        const fakeRecord: UserRecord = {
-          githubToken: 'test-token',
-          scopes: [],
-          username: '',
-          fullname: '',
-          avatarUrl: '',
-          lastKnownUpdate: '',
-          featureLastViewed: {
-            enabledAt: 0,
-          }
-        };
-        return fakeRecord;
-      });
-
-      const activity = await issueHasNewActivity('example-username', 2, 1);
+      const fakeDetails: FeatureDetails = {
+        enabledAt: 0,
+      };
+      const activity = await issueHasNewActivity(fakeDetails, 2, 1);
       t.deepEqual(activity, true, 'issue has activity');
     });

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -35,6 +35,7 @@ export interface PullRequest {
   avatarUrl: string;
   status: PullRequestStatus;
   events: PullRequestEvent[];
+  hasNewActivity: boolean;
 }
 
 export type PullRequestStatus =


### PR DESCRIPTION
More steps towards: #352

This hooks up the featureEnabled API and adds `hasNewActivity` to the PullRequests API.

Will follow up with the assigned issues next and then add the UI, let me know if you'd rather have these features added immediately.