### PR TITLE
Enable bot avatars

### DIFF
--- a/src/server/apis/dash-data.ts
+++ b/src/server/apis/dash-data.ts
@@ -349,7 +349,7 @@ export function convertPrFields(fields: prFieldsFragment): api.PullRequest {
     events: [],
   };
 
-  if (fields.author && fields.author.__typename === 'User') {
+  if (fields.author) {
     pr.author = fields.author.login;
     pr.avatarUrl = fields.author.avatarUrl;
   }


### PR DESCRIPTION
I noticed that a bot creating PR's for auto-updating my dependencies wasn't showing it's avatar. Looks like we restrict to user type even though the required fields are available for any type of author. Seems safe to remove for these fields.