### PR TITLE
Moving replay server and pixel tester under test directory

### DIFF
--- a/src/server/dash-server.ts
+++ b/src/server/dash-server.ts
@@ -23,7 +23,7 @@ import {requireLogin} from './utils/require-login';
 const STATIC_EXT = ['html'];
 
 export class DashServer {
-  private app: express.Express;
+  private app: Express;
   private server: Server|null;
 
   constructor() {

--- a/src/server/models/userModel.ts
+++ b/src/server/models/userModel.ts
@@ -14,9 +14,7 @@ export const TOKEN_COLLECTION_NAME = 'user-tokens';
 
 export const REQUIRED_SCOPES = ['repo'];
 
-export interface FeatureDetails {
-  enabledAt: number;
-}
+export interface FeatureDetails { enabledAt: number; }
 
 export interface UserRecord {
   githubToken: string;

--- a/src/test/cli/metrics/issue-count-test.ts
+++ b/src/test/cli/metrics/issue-count-test.ts
@@ -2,8 +2,8 @@ import anyTest, {TestInterface} from 'ava';
 import {Server} from 'http';
 
 import {getIssueCounts} from '../../../cli/metrics/issue-counts';
-import {startTestReplayServer} from '../../../replay-server';
 import {initGithub} from '../../../utils/github';
+import {startTestReplayServer} from '../../utils/replay-server';
 
 const test = anyTest as TestInterface<{server: Server}>;
 

--- a/src/test/cli/metrics/review-coverage-test.ts
+++ b/src/test/cli/metrics/review-coverage-test.ts
@@ -2,8 +2,8 @@ import anyTest, {TestInterface} from 'ava';
 import {Server} from 'http';
 
 import {getReviewCoverage} from '../../../cli/metrics/review-coverage';
-import {startTestReplayServer} from '../../../replay-server';
 import {initGithub} from '../../../utils/github';
+import {startTestReplayServer} from '../../utils/replay-server';
 
 const test = anyTest as TestInterface<{server: Server}>;
 

--- a/src/test/cli/metrics/review-latency-test.ts
+++ b/src/test/cli/metrics/review-latency-test.ts
@@ -2,8 +2,8 @@ import anyTest, {TestInterface} from 'ava';
 import {Server} from 'http';
 
 import {getReviewLatency} from '../../../cli/metrics/review-latency';
-import {startTestReplayServer} from '../../../replay-server';
 import {initGithub} from '../../../utils/github';
+import {startTestReplayServer} from '../../utils/replay-server';
 
 const test = anyTest as TestInterface<{server: Server}>;
 

--- a/src/test/cli/metrics/stars-test.ts
+++ b/src/test/cli/metrics/stars-test.ts
@@ -2,8 +2,8 @@ import anyTest, {TestInterface} from 'ava';
 import {Server} from 'http';
 
 import {getStars} from '../../../cli/metrics/stars';
-import {startTestReplayServer} from '../../../replay-server';
 import {initGithub} from '../../../utils/github';
+import {startTestReplayServer} from '../../utils/replay-server';
 
 const test = anyTest as TestInterface<{server: Server}>;
 

--- a/src/test/pixel/pixel-test.ts
+++ b/src/test/pixel/pixel-test.ts
@@ -4,14 +4,14 @@ import * as puppeteer from 'puppeteer';
 import * as sinon from 'sinon';
 import {SinonSandbox} from 'sinon';
 
-import {testScreenshot} from '../../pixel-tester';
-import {startTestReplayServer} from '../../replay-server';
 import {DashServer} from '../../server/dash-server';
 import {pullRequestsModel} from '../../server/models/pullRequestsModel';
 import {userModel} from '../../server/models/userModel';
 import {initFirestore} from '../../utils/firestore';
 import {initGithub} from '../../utils/github';
 import {newFakeUserRecord} from '../utils/newFakeUserRecord';
+import {testScreenshot} from '../utils/pixel-tester';
+import {startTestReplayServer} from '../utils/replay-server';
 
 type TestContext = {
   replayServer: Server,

--- a/src/test/server/apis/incoming-prs-test.ts
+++ b/src/test/server/apis/incoming-prs-test.ts
@@ -1,12 +1,12 @@
 import anyTest, {TestInterface} from 'ava';
 
-import {startTestReplayServer} from '../../../replay-server';
 import {fetchIncomingData} from '../../../server/apis/dash-data';
 import {IncomingDashResponse, PullRequest} from '../../../types/api';
 import {PullRequestReviewState} from '../../../types/gql-types';
 import {initFirestore} from '../../../utils/firestore';
 import {initGithub} from '../../../utils/github';
 import {newFakeUserRecord} from '../../utils/newFakeUserRecord';
+import {startTestReplayServer} from '../../utils/replay-server';
 
 type TestContext = {
   data: IncomingDashResponse,

--- a/src/test/server/apis/issues-test.ts
+++ b/src/test/server/apis/issues-test.ts
@@ -3,13 +3,13 @@ import {Server} from 'http';
 import * as sinon from 'sinon';
 import {SinonSandbox} from 'sinon';
 
-import {startTestReplayServer} from '../../../replay-server';
 import {handleGetIssues} from '../../../server/apis/issues';
 import {userModel} from '../../../server/models/userModel';
 import {IssuesResponse} from '../../../types/api';
 import {initFirestore} from '../../../utils/firestore';
 import {initGithub} from '../../../utils/github';
 import {getTestTokens} from '../../get-test-tokens';
+import {startTestReplayServer} from '../../utils/replay-server';
 
 type TestContext = {
   replayServer: Server,

--- a/src/test/server/apis/outgoing-prs-2-test.ts
+++ b/src/test/server/apis/outgoing-prs-2-test.ts
@@ -1,12 +1,12 @@
 import anyTest, {TestInterface} from 'ava';
 
-import {startTestReplayServer} from '../../../replay-server';
 import {fetchOutgoingData} from '../../../server/apis/dash-data/fetch-outgoing-data';
 import {OutgoingDashResponse, OutgoingPullRequest} from '../../../types/api';
 import {PullRequestReviewState} from '../../../types/gql-types';
 import {initFirestore} from '../../../utils/firestore';
 import {initGithub} from '../../../utils/github';
 import {newFakeUserRecord} from '../../utils/newFakeUserRecord';
+import {startTestReplayServer} from '../../utils/replay-server';
 
 type TestContext = {
   data: OutgoingDashResponse,

--- a/src/test/server/apis/outgoing-prs-test.ts
+++ b/src/test/server/apis/outgoing-prs-test.ts
@@ -1,12 +1,12 @@
 import anyTest, {TestInterface} from 'ava';
 
-import {startTestReplayServer} from '../../../replay-server';
 import {fetchOutgoingData} from '../../../server/apis/dash-data/fetch-outgoing-data';
 import {OutgoingDashResponse, OutgoingPullRequest} from '../../../types/api';
 import {MergeableState, PullRequestReviewState} from '../../../types/gql-types';
 import {initFirestore} from '../../../utils/firestore';
 import {initGithub} from '../../../utils/github';
 import {newFakeUserRecord} from '../../utils/newFakeUserRecord';
+import {startTestReplayServer} from '../../utils/replay-server';
 
 type TestContext = {
   data: OutgoingDashResponse,

--- a/src/test/server/apis/webhook-test.ts
+++ b/src/test/server/apis/webhook-test.ts
@@ -5,7 +5,6 @@ import * as path from 'path';
 import * as sinon from 'sinon';
 import {SinonSandbox} from 'sinon';
 
-import {startTestReplayServer} from '../../../replay-server';
 import * as notificationController from '../../../server/controllers/notifications';
 import {handlePullRequest} from '../../../server/controllers/webhook-events/pull-request';
 import {pullRequestsModel} from '../../../server/models/pullRequestsModel';
@@ -14,6 +13,7 @@ import * as getPRIDModule from '../../../server/utils/get-gql-pr-id';
 import {initFirestore} from '../../../utils/firestore';
 import {initGithub} from '../../../utils/github';
 import {initSecrets} from '../../../utils/secrets';
+import {startTestReplayServer} from '../../utils/replay-server';
 
 const hookJsonDir = path.join(__dirname, '..', '..', 'static', 'webhook-data');
 

--- a/src/test/server/controllers/webhook-events/pull-request-review-test.ts
+++ b/src/test/server/controllers/webhook-events/pull-request-review-test.ts
@@ -3,7 +3,6 @@ import {Server} from 'http';
 import * as sinon from 'sinon';
 import {SinonSandbox, SinonStub} from 'sinon';
 
-import {startTestReplayServer} from '../../../../replay-server';
 import * as notificationController from '../../../../server/controllers/notifications';
 import {handlePullRequestReview} from '../../../../server/controllers/webhook-events/pull-request-review';
 import {PullRequestReviewHook} from '../../../../server/controllers/webhook-events/types';
@@ -14,6 +13,7 @@ import {PullRequestDetails} from '../../../../server/utils/get-pr-from-commit';
 import {initFirestore} from '../../../../utils/firestore';
 import {initGithub} from '../../../../utils/github';
 import {initSecrets} from '../../../../utils/secrets';
+import {startTestReplayServer} from '../../../utils/replay-server';
 
 const TEST_SECRETS = {
   GITHUB_CLIENT_ID: 'ClientID',

--- a/src/test/server/controllers/webhook-events/status-test.ts
+++ b/src/test/server/controllers/webhook-events/status-test.ts
@@ -3,7 +3,6 @@ import {Server} from 'http';
 import * as sinon from 'sinon';
 import {SinonSandbox, SinonStub} from 'sinon';
 
-import {startTestReplayServer} from '../../../../replay-server';
 import * as notificationController from '../../../../server/controllers/notifications';
 import {handleStatus} from '../../../../server/controllers/webhook-events/status';
 import {StatusHook} from '../../../../server/controllers/webhook-events/types';
@@ -15,6 +14,7 @@ import * as performAutomergeModule from '../../../../server/utils/perform-autome
 import {initFirestore} from '../../../../utils/firestore';
 import {initGithub} from '../../../../utils/github';
 import {initSecrets} from '../../../../utils/secrets';
+import {startTestReplayServer} from '../../../utils/replay-server';
 
 const TEST_SECRETS = {
   GITHUB_CLIENT_ID: 'ClientID',

--- a/src/test/server/dash-server-test.ts
+++ b/src/test/server/dash-server-test.ts
@@ -21,3 +21,9 @@ test('/webhook/ ping should return 200', async (t) => {
   t.deepEqual(textResponse, '');
   t.true(response.ok);
 });
+
+test('should resolve if closed without starting', async (t) => {
+  const server = new DashServer();
+  await server.close();
+  t.pass();
+});

--- a/src/test/server/models/repositoryModel-test.ts
+++ b/src/test/server/models/repositoryModel-test.ts
@@ -3,11 +3,11 @@ import {Server} from 'http';
 import * as sinon from 'sinon';
 import {SinonSandbox} from 'sinon';
 
-import {startTestReplayServer} from '../../../replay-server';
 import {MAX_CACHE_AGE, repositoryModel} from '../../../server/models/repositoryModel';
 import {initFirestore} from '../../../utils/firestore';
 import {github, initGithub} from '../../../utils/github';
 import {newFakeUserRecord} from '../../utils/newFakeUserRecord';
+import {startTestReplayServer} from '../../utils/replay-server';
 
 type TestContext = {
   server: Server,

--- a/src/test/server/models/userModel-test.ts
+++ b/src/test/server/models/userModel-test.ts
@@ -3,13 +3,13 @@ import * as crypto from 'crypto';
 import * as http from 'http';
 import * as sinon from 'sinon';
 
-import {startTestReplayServer} from '../../../replay-server';
 import {TOKEN_COLLECTION_NAME, userModel, USERS_COLLECTION_NAME} from '../../../server/models/userModel';
 import {firestore, initFirestore} from '../../../utils/firestore';
 import * as githubFactory from '../../../utils/github';
 import {initGithub} from '../../../utils/github';
 import {getTestTokens} from '../../get-test-tokens';
 import {FAKE_USERNAME, newFakeUserRecord} from '../../utils/newFakeUserRecord';
+import {startTestReplayServer} from '../../utils/replay-server';
 
 const TEST_USER_TOKEN = 'fake-user-token-abcd';
 

--- a/src/test/server/util/my-repos-test.ts
+++ b/src/test/server/util/my-repos-test.ts
@@ -1,8 +1,8 @@
 import test from 'ava';
 
-import {startTestReplayServer} from '../../../replay-server';
 import {getMyRepos} from '../../../server/utils/my-repos';
 import {initGithub} from '../../../utils/github';
+import {startTestReplayServer} from '../../utils/replay-server';
 
 test('top contributed repos for samuelli', async (t) => {
   const {server, url} = await startTestReplayServer(t);

--- a/src/test/utils/pixel-tester.ts
+++ b/src/test/utils/pixel-tester.ts
@@ -11,7 +11,8 @@ import pixelmatch = require('pixelmatch');
 // tslint:disable-next-line:no-require-imports
 import mergeImg = require('merge-img');
 
-const goldensRoot = path.join(__dirname, '..', 'goldens');
+const projectRoot = path.join(__dirname, '..', '..');
+const goldensRoot = path.join(projectRoot, '..', 'goldens');
 
 /**
  * Given paths to two images, will return whether or not the two images are the

--- a/src/test/utils/replay-server.ts
+++ b/src/test/utils/replay-server.ts
@@ -5,7 +5,8 @@ import * as http from 'http';
 import * as path from 'path';
 import * as request from 'request';
 
-const replayRoot = path.join(__dirname, '..', 'replays');
+const projectRoot = path.join(__dirname, '..', '..');
+const replayRoot = path.join(projectRoot, '..', 'replays');
 const githubApiUrl = 'https://api.github.com/graphql';
 const githubJsonUrl = 'https://api.github.com';
 const timeout = 1000 * 10;
@@ -37,7 +38,7 @@ export async function startTestReplayServer(
   const replayDir = path.join(replayRoot, testTitle.replace(/\s+/g, '-'));
 
   if (record) {
-    const tokensPath = path.join(__dirname, '..', 'tokens.json');
+    const tokensPath = path.join(projectRoot, 'tokens.json');
     if (!await fsExtra.pathExists(tokensPath)) {
       throw new Error('Missing tokens.json with test tokens.');
     }


### PR DESCRIPTION
Wanted to do some work on our code coverage and touch up consistency in a few places and then noticed coverage was running on these files which we arguably do not want.