### PR TITLE
Fixing naming difference

### DIFF
--- a/src/client/public/scripts/settings/org-webhook-list.ts
+++ b/src/client/public/scripts/settings/org-webhook-list.ts
@@ -75,7 +75,7 @@ function hookTemplate(org: OrgWebHookState) {
 function requestPermissionTemplate() {
   const readOrgsClick = () => {
     window.location.href =
-        `/signin?scope=read:org admin:org_hook&final-redirect=${
+        `/signin?scopes=read:org admin:org_hook&final-redirect=${
             window.location.href}`;
   };
   const requestPermissionTemplate = html`<p><button on-click="${


### PR DESCRIPTION
`scope` should have been `scopes` in settings.