### PR TITLE
Change empty message to an element with attributes

### DIFF
--- a/src/client/public/scripts/components/base-element.ts
+++ b/src/client/public/scripts/components/base-element.ts
@@ -24,10 +24,10 @@ export abstract class BaseElement extends HTMLElement {
   }
 
   connectedCallback() {
-    this.renderCallback();
+    this.requestRender();
   }
 
-  renderCallback() {
+  requestRender() {
     this._debouncer(() => {
       litRender(this.render(), this);
     });
@@ -37,7 +37,7 @@ export abstract class BaseElement extends HTMLElement {
       _name: string,
       _oldValue: string|null,
       _newValue: string|null) {
-    this.renderCallback();
+    this.requestRender();
   }
 
   abstract render(): TemplateResult;

--- a/src/client/public/scripts/components/base-element.ts
+++ b/src/client/public/scripts/components/base-element.ts
@@ -1,4 +1,4 @@
-import {render} from '../../../../../node_modules/lit-html/lib/lit-extended.js';
+import {render as litRender} from '../../../../../node_modules/lit-html/lib/lit-extended.js';
 import {TemplateResult} from '../../../../../node_modules/lit-html/lit-html.js';
 
 type Debouncer = (task: Function) => Promise<void>;
@@ -17,11 +17,10 @@ function createDebouncer(): Debouncer {
 }
 
 export abstract class BaseElement extends HTMLElement {
-  private _debouncer: Debouncer;
+  private _debouncer: Debouncer = createDebouncer();
 
   constructor() {
     super();
-    this._debouncer = createDebouncer();
   }
 
   connectedCallback() {
@@ -30,7 +29,7 @@ export abstract class BaseElement extends HTMLElement {
 
   renderCallback() {
     this._debouncer(() => {
-      render(this.render(), this);
+      litRender(this.render(), this);
     });
   }
 

--- a/src/client/public/scripts/components/base-element.ts
+++ b/src/client/public/scripts/components/base-element.ts
@@ -1,9 +1,27 @@
 import {render} from '../../../../../node_modules/lit-html/lib/lit-extended.js';
 import {TemplateResult} from '../../../../../node_modules/lit-html/lit-html.js';
 
+type Debouncer = (task: Function) => Promise<void>;
+
+function createDebouncer(): Debouncer {
+  let queued = false;
+  return async (task: Function) => {
+    if (queued) {
+      return;
+    }
+    queued = true;
+    await Promise.resolve();
+    queued = false;
+    task();
+  };
+}
+
 export abstract class BaseElement extends HTMLElement {
+  private _debouncer: Debouncer;
+
   constructor() {
     super();
+    this._debouncer = createDebouncer();
   }
 
   connectedCallback() {
@@ -11,7 +29,16 @@ export abstract class BaseElement extends HTMLElement {
   }
 
   renderCallback() {
-    render(this.render(), this);
+    this._debouncer(() => {
+      render(this.render(), this);
+    });
+  }
+
+  attributeChangedCallback(
+      _name: string,
+      _oldValue: string|null,
+      _newValue: string|null) {
+    this.renderCallback();
   }
 
   abstract render(): TemplateResult;

--- a/src/client/public/scripts/components/empty-message.ts
+++ b/src/client/public/scripts/components/empty-message.ts
@@ -1,20 +1,29 @@
 import {html} from '../../../../../node_modules/lit-html/lib/lit-extended.js';
 
-export type EmptyMessage = {
-  title: string; description: string;
-};
+import {BaseElement} from './base-element.js';
 
-export function emptyTemplate(message: EmptyMessage) {
-  return html`
-  <div class="empty-message">
+export abstract class EmptyMessage extends BaseElement {
+  render() {
+    return html`
     <div class="empty-message__avatar">
       <div class="empty-message__sun"></div>
     </div>
 
     <div>
-      <div class="small-heading">${message.title}</div>
-      <div class="empty-message__description">${message.description}</div>
-    </div>
-  </div>
-  `;
+      <div class="small-heading">${this.getAttribute('title')}</div>
+      <div class="empty-message__description">${
+        this.getAttribute('description')}</div>
+    </div>`;
+  }
+
+  static get observedAttributes(): string[] {
+    return ['title', 'description'];
+  }
+}
+
+customElements.define('empty-message', EmptyMessage);
+
+export function createEmptyMessage(title: string, description: string) {
+  return html`<empty-message title$="${title}" description$="${
+      description}"></empty-message>`;
 }

--- a/src/client/public/scripts/components/nav-element.ts
+++ b/src/client/public/scripts/components/nav-element.ts
@@ -13,7 +13,7 @@ export class NavElement extends BaseElement {
 
   set user(user: api.DashboardUser|null) {
     this._user = user;
-    this.renderCallback();
+    this.requestRender();
   }
 
   _userTemplate(): TemplateResult {

--- a/src/client/public/scripts/dash/dash.ts
+++ b/src/client/public/scripts/dash/dash.ts
@@ -43,11 +43,10 @@ function renderOutgoing() {
 
   render(
       outgoingPrListTemplate(
-          outgoingPrs, filterController.getFilter('outgoing-prs'), {
-            title: 'No outgoing pull requests',
-            description:
-                'When you open new pull requests, they\'ll appear here.'
-          }),
+          outgoingPrs,
+          filterController.getFilter('outgoing-prs'),
+          'No outgoing pull requests',
+          'When you open new pull requests, they\'ll appear here.'),
       (document.querySelector('.outgoing-prs__list') as Element));
 }
 
@@ -59,11 +58,10 @@ function renderIncoming() {
 
   render(
       genericPrListTemplate(
-          incomingPrs, filterController.getFilter('incoming-prs'), {
-            title: 'No incoming pull requests',
-            description:
-                'When you\'re added as a reviewer to a pull request, they\'ll appear here.'
-          }),
+          incomingPrs,
+          filterController.getFilter('incoming-prs'),
+          'No incoming pull requests',
+          'When you\'re added as a reviewer to a pull request, they\'ll appear here.'),
       (document.querySelector('.incoming-prs__list') as Element));
 }
 
@@ -72,10 +70,10 @@ async function renderIssues() {
 
   render(
       genericIssueListTemplate(
-          issues, filterController.getFilter('assigned-issues'), {
-            title: 'No issues assigned to you',
-            description: 'When you\'re assigned issues, they\'ll appear here.'
-          }),
+          issues,
+          filterController.getFilter('assigned-issues'),
+          'No issues assigned to you',
+          'When you\'re assigned issues, they\'ll appear here.'),
       (document.querySelector('.assigned-issues__list') as Element));
 }
 

--- a/src/client/public/scripts/dash/issues.ts
+++ b/src/client/public/scripts/dash/issues.ts
@@ -1,7 +1,11 @@
+import '../components/empty-message.js';
+
 import {html} from '../../../../../node_modules/lit-html/lib/lit-extended.js';
 import * as api from '../../../../types/api.js';
 import {genericDashboardRowTemplate, StatusDisplay} from '../components/dashboard-row.js';
-import {EmptyMessage, emptyTemplate} from '../components/empty-message.js';
+
+import {createEmptyMessage} from '../components/empty-message.js';
+
 import {FilterState} from './filter-controller.js';
 
 function statusToDisplay(): StatusDisplay {
@@ -27,7 +31,8 @@ function popularityTemplate(popularity: api.Popularity) {
 export function genericIssueListTemplate(
     issues: api.Issue[],
     filter: FilterState|undefined,
-    emptyMessage: EmptyMessage) {
+    emptyMessageTitle: string,
+    emptyMessageDescription: string) {
   // Issuses currently are only of one type.
   const filtered = filter && filter['actionable'];
   if (issues.length && !filtered) {
@@ -48,6 +53,6 @@ export function genericIssueListTemplate(
           [popularityTemplate(issue.popularity)]);
     })}`;
   } else {
-    return emptyTemplate(emptyMessage);
+    return createEmptyMessage(emptyMessageTitle, emptyMessageDescription);
   }
 }

--- a/src/client/public/scripts/dash/prs.ts
+++ b/src/client/public/scripts/dash/prs.ts
@@ -1,24 +1,28 @@
+import '../components/empty-message.js';
+
 import {html} from '../../../../../node_modules/lit-html/lib/lit-extended.js';
 import {TemplateResult} from '../../../../../node_modules/lit-html/lit-html.js';
 import * as api from '../../../../types/api.js';
 import {genericDashboardRowEventTemplate, genericDashboardRowTemplate, StatusDisplay} from '../components/dashboard-row.js';
-import {EmptyMessage, emptyTemplate} from '../components/empty-message.js';
+import {createEmptyMessage} from '../components/empty-message.js';
 
 import {getAutoMergeOptions} from './auto-merge-events.js';
 import {FilterState} from './filter-controller.js';
 import {parseAsEventModel} from './pr-event.js';
 
+
 export function genericPrListTemplate(
     prList: api.PullRequest[],
     filter: FilterState|undefined,
-    emptyMessage: EmptyMessage) {
+    emptyMessageTitle: string,
+    emptyMessageDescription: string) {
   prList = applyFilter(filter, prList);
   if (prList.length) {
     return html`${prList.map((pr) => {
       return getPRRowTemplate(pr);
     })}`;
   } else {
-    return emptyTemplate(emptyMessage);
+    return createEmptyMessage(emptyMessageTitle, emptyMessageDescription);
   }
 }
 
@@ -40,14 +44,15 @@ function applyFilter<T extends api.PullRequest>(
 export function outgoingPrListTemplate(
     prList: api.OutgoingPullRequest[],
     filter: FilterState|undefined,
-    emptyMessage: EmptyMessage) {
+    emptyMessageTitle: string,
+    emptyMessageDescription: string) {
   prList = applyFilter(filter, prList);
   if (prList.length) {
     return html`${prList.map((pr) => {
       return outgoingPrTemplate(pr);
     })}`;
   } else {
-    return emptyTemplate(emptyMessage);
+    return createEmptyMessage(emptyMessageTitle, emptyMessageDescription);
   }
 }
 

--- a/src/client/public/styles/components/empty-message.css
+++ b/src/client/public/styles/components/empty-message.css
@@ -1,7 +1,7 @@
 @import "../variables/dimens.css";
 @import "../variables/colors.css";
 
-.empty-message {
+empty-message {
   display: flex;
 }
 

--- a/src/server/models/userModel.ts
+++ b/src/server/models/userModel.ts
@@ -14,9 +14,7 @@ export const TOKEN_COLLECTION_NAME = 'user-tokens';
 
 export const REQUIRED_SCOPES = ['repo'];
 
-export interface FeatureDetails {
-  enabledAt: number;
-}
+export interface FeatureDetails { enabledAt: number; }
 
 export interface UserRecord {
   githubToken: string;


### PR DESCRIPTION
This adds a debouncer to the base element. When observed attributes are changed, `renderCallback()` is called, where `observedAttributes()` is defined by the element implementation.

@cdata PTAL at `base-element` changes. 

