### PR TITLE
Change review latency to use PR creation instead

### DIFF
--- a/src/cli/common.ts
+++ b/src/cli/common.ts
@@ -88,6 +88,7 @@ export function getReviewsForPullRequest(pullRequest: PullRequest): Review[] {
         !authors.has(review.author.login)) {
       authors.add(review.author.login);
       reviewEvents.push({
+        createdAt: pullRequest.createdAt,
         latency: new Date(review.submittedAt).getTime() -
             new Date(pullRequest.createdAt).getTime(),
         reviewedAt: review.submittedAt,
@@ -110,6 +111,7 @@ export type PullRequest = {
 };
 
 export type Review = {
+  createdAt: string,
   reviewedAt: string,
   latency: number,
 };

--- a/src/cli/metrics/review-latency.ts
+++ b/src/cli/metrics/review-latency.ts
@@ -48,7 +48,7 @@ export class ReviewLatencyResult implements MetricResult {
     // Sort results into date buckets.
     const buckets: Map<string, Review[]> = new Map();
     for (const entry of this.reviews) {
-      const date = new Date(entry.reviewedAt);
+      const date = new Date(entry.createdAt);
       // Sort into weekly buckets.
       date.setDate(date.getDate() - date.getDay());
       const dateKey = date.toDateString();
@@ -92,7 +92,7 @@ export async function getReviewLatency(opts: ReviewLatencyOpts):
     repos = await getOrgRepos(opts.org);
   }
 
-  const fetches = [];
+  const fetches: Array<Promise<PullRequest[]>> = [];
   const reviews: Review[] = [];
 
   for (const {owner, name} of repos) {
@@ -101,7 +101,7 @@ export async function getReviewLatency(opts: ReviewLatencyOpts):
   for (const prs of fetches) {
     for (const pr of await prs) {
       for (const review of getReviewsForPullRequest(pr)) {
-        if (new Date(review.reviewedAt) > opts.since) {
+        if (new Date(review.createdAt) > opts.since) {
           reviews.push(review);
         }
       }


### PR DESCRIPTION
Fixes #401.

When looking at review latency in a given period of time, we were looking at when the review was done and factoring it in then. This changes it to instead use the PR creation time. This allows for more accurate reporting in determining trends in how long it takes for a PR to get reviewed.