### PR TITLE
Fixing FF support for CustomElements

### DIFF
--- a/src/client/private-pages/index.html
+++ b/src/client/private-pages/index.html
@@ -11,7 +11,7 @@
   <link rel="icon" type="image/png" href="/images/favicon-32x32.png" sizes="32x32">
   <link rel="icon" type="image/png" href="/images/favicon-16x16.png" sizes="16x16">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons+Extended" rel="stylesheet">
-  <script nomodule src="/node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
+  <script src="/node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
Firefox 60 supports modules but doesn't seem to work with custom elements.

Removing the nomodule option gets everything back up and running in FF. 