### PR TITLE
Add basic stackdriver error reporting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -772,6 +772,123 @@
         }
       }
     },
+    "@google-cloud/error-reporting": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/error-reporting/-/error-reporting-0.4.0.tgz",
+      "integrity": "sha512-RB81eDMghu3ATVvT/69JTykVnR+0TJSuPMZvaLaEUks9u3NcvRi39QKOnXt3FLtyFRkacvNgEMB5wJSfTzBvPw==",
+      "requires": {
+        "@google-cloud/common": "0.17.0",
+        "is": "3.2.1",
+        "lodash.has": "4.5.2"
+      },
+      "dependencies": {
+        "@google-cloud/common": {
+          "version": "0.17.0",
+          "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.17.0.tgz",
+          "integrity": "sha512-HRZLSU762E6HaKoGfJGa8W95yRjb9rY7LePhjaHK9ILAnFacMuUGVamDbTHu1csZomm1g3tZTtXfX/aAhtie/Q==",
+          "requires": {
+            "array-uniq": "1.0.3",
+            "arrify": "1.0.1",
+            "concat-stream": "1.6.0",
+            "create-error-class": "3.0.2",
+            "duplexify": "3.5.3",
+            "ent": "2.2.0",
+            "extend": "3.0.1",
+            "google-auto-auth": "0.10.0",
+            "is": "3.2.1",
+            "log-driver": "1.2.7",
+            "methmeth": "1.1.0",
+            "modelo": "4.2.3",
+            "request": "2.83.0",
+            "retry-request": "3.3.1",
+            "split-array-stream": "1.0.3",
+            "stream-events": "1.0.2",
+            "string-format-obj": "1.1.1",
+            "through2": "2.0.3"
+          }
+        },
+        "gcp-metadata": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.6.3.tgz",
+          "integrity": "sha512-MSmczZctbz91AxCvqp9GHBoZOSbJKAICV7Ow/AIWSJZRrRchUd5NL1b2P4OfP+4m490BEUPhhARfpHdqCxuCvg==",
+          "requires": {
+            "axios": "0.18.0",
+            "extend": "3.0.1",
+            "retry-axios": "0.3.2"
+          }
+        },
+        "google-auth-library": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-1.4.0.tgz",
+          "integrity": "sha512-vWRx6pJulK7Y5V/Xyr7MPMlx2mWfmrUVbcffZ7hpq8ElFg5S8WY6PvjMovdcr6JfuAwwpAX4R0I1XOcyWuBcUw==",
+          "requires": {
+            "axios": "0.18.0",
+            "gcp-metadata": "0.6.3",
+            "gtoken": "2.3.0",
+            "jws": "3.1.4",
+            "lodash.isstring": "4.0.1",
+            "lru-cache": "4.1.2",
+            "retry-axios": "0.3.2"
+          }
+        },
+        "google-auto-auth": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.10.0.tgz",
+          "integrity": "sha512-R6m473OqgZacPvlidJ0aownTlUWyLy654ugjKSXyi1ffIicXlXg3wMfse9T9zxqG6w01q6K1iG+b7dImMkVJ2Q==",
+          "requires": {
+            "async": "2.6.0",
+            "gcp-metadata": "0.6.3",
+            "google-auth-library": "1.4.0",
+            "request": "2.83.0"
+          }
+        },
+        "google-p12-pem": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-1.0.2.tgz",
+          "integrity": "sha512-+EuKr4CLlGsnXx4XIJIVkcKYrsa2xkAmCvxRhX2HsazJzUBAJ35wARGeApHUn4nNfPD03Vl057FskNr20VaCyg==",
+          "requires": {
+            "node-forge": "0.7.5",
+            "pify": "3.0.0"
+          }
+        },
+        "gtoken": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-2.3.0.tgz",
+          "integrity": "sha512-Jc9/8mV630cZE9FC5tIlJCZNdUjwunvlwOtCz6IDlaiB4Sz68ki29a1+q97sWTnTYroiuF9B135rod9zrQdHLw==",
+          "requires": {
+            "axios": "0.18.0",
+            "google-p12-pem": "1.0.2",
+            "jws": "3.1.4",
+            "mime": "2.3.1",
+            "pify": "3.0.0"
+          }
+        },
+        "log-driver": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
+          "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg=="
+        },
+        "lru-cache": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
+          "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
+        },
+        "mime": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
+          "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
+        },
+        "node-forge": {
+          "version": "0.7.5",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
+          "integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ=="
+        }
+      }
+    },
     "@google-cloud/firestore": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-0.11.2.tgz",
@@ -2297,6 +2414,15 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+    },
+    "axios": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "requires": {
+        "follow-redirects": "1.4.1",
+        "is-buffer": "1.1.6"
+      }
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -6373,6 +6499,24 @@
       "requires": {
         "inherits": "2.0.3",
         "readable-stream": "2.3.3"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
+      "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
+      "requires": {
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "for-each": {
@@ -10870,8 +11014,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -11891,6 +12034,11 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
+    },
+    "lodash.has": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
+      "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI="
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -18241,8 +18389,7 @@
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "pstree.remy": {
       "version": "1.1.0",
@@ -18926,6 +19073,11 @@
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
+    },
+    "retry-axios": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/retry-axios/-/retry-axios-0.3.2.tgz",
+      "integrity": "sha512-jp4YlI0qyDFfXiXGhkCOliBN1G7fRH03Nqy8YdShzGqbY5/9S2x/IR6C88ls2DFkbWuL3ASkP7QD3pVrNpPgwQ=="
     },
     "retry-request": {
       "version": "3.3.1",
@@ -21592,8 +21744,7 @@
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-      "dev": true
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
       "version": "3.32.0",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "vinyl-source-stream": "^2.0.0"
   },
   "dependencies": {
+    "@google-cloud/error-reporting": "^0.4.0",
     "@google-cloud/firestore": "^0.11.2",
     "@material/switch": "^0.30.0",
     "@types/puppeteer": "^1.0.0",


### PR DESCRIPTION
Fixes #261.

This adds basic support for stackdriver error reporting using their Express integration. Once this is up an running, we can also [manually report errors](https://cloud.google.com/error-reporting/docs/setup/nodejs#reporting_errors) and have these surface in stackdriver.