### PR TITLE
Adds base element @property decorator which supports attr sync

### DIFF
--- a/src/client/public/scripts/components/empty-message.ts
+++ b/src/client/public/scripts/components/empty-message.ts
@@ -17,8 +17,6 @@ export abstract class EmptyMessage extends BaseElement {
       <div class="empty-message__description">${this.description}</div>
     </div>`;
   }
-
-  // static observedAttributes = ['title', 'description'];
 }
 
 customElements.define('empty-message', EmptyMessage);

--- a/src/client/public/scripts/components/empty-message.ts
+++ b/src/client/public/scripts/components/empty-message.ts
@@ -1,8 +1,11 @@
 import {html} from '../../../../../node_modules/lit-html/lib/lit-extended.js';
 
-import {BaseElement} from './base-element.js';
+import {BaseElement, property} from './base-element.js';
 
 export abstract class EmptyMessage extends BaseElement {
+  @property({attribute: true}) title = '';
+  @property({attribute: true}) description = '';
+
   render() {
     return html`
     <div class="empty-message__avatar">
@@ -10,15 +13,12 @@ export abstract class EmptyMessage extends BaseElement {
     </div>
 
     <div>
-      <div class="small-heading">${this.getAttribute('title')}</div>
-      <div class="empty-message__description">${
-        this.getAttribute('description')}</div>
+      <div class="small-heading">${this.title}</div>
+      <div class="empty-message__description">${this.description}</div>
     </div>`;
   }
 
-  static get observedAttributes(): string[] {
-    return ['title', 'description'];
-  }
+  // static observedAttributes = ['title', 'description'];
 }
 
 customElements.define('empty-message', EmptyMessage);

--- a/src/client/public/scripts/components/filter-legend.ts
+++ b/src/client/public/scripts/components/filter-legend.ts
@@ -7,23 +7,14 @@ export type FilterLegendItem = {
   selected?: boolean,
 };
 
-import {BaseElement} from './base-element.js';
+import {BaseElement, property} from './base-element.js';
 
 export class FilterLegend extends BaseElement {
-  private _filters: FilterLegendItem[] = [];
+  @property() filters: FilterLegendItem[] = [];
 
   constructor() {
     super();
     this.classList.add('small-heading');
-  }
-
-  get filters() {
-    return this._filters;
-  }
-
-  set filters(filters: FilterLegendItem[]) {
-    this._filters = filters;
-    this.requestRender();
   }
 
   _renderFilter(filter: FilterLegendItem) {

--- a/src/client/public/scripts/components/nav-element.ts
+++ b/src/client/public/scripts/components/nav-element.ts
@@ -2,19 +2,10 @@ import {html} from '../../../../../node_modules/lit-html/lib/lit-extended.js';
 import {TemplateResult} from '../../../../../node_modules/lit-html/lit-html.js';
 import * as api from '../../../../types/api.js';
 
-import {BaseElement} from './base-element.js';
+import {BaseElement, property} from './base-element.js';
 
 export class NavElement extends BaseElement {
-  private _user: api.DashboardUser|null = null;
-
-  get user(): api.DashboardUser|null {
-    return this._user;
-  }
-
-  set user(user: api.DashboardUser|null) {
-    this._user = user;
-    this.requestRender();
-  }
+  @property() user: api.DashboardUser|null = null;
 
   _userTemplate(): TemplateResult {
     if (!this.user) {
@@ -28,28 +19,30 @@ export class NavElement extends BaseElement {
       avatarUrl = '/images/incognito.svg';
     }
 
-    const buttons = html
-    `<a href="/settings" title="Settings" class="settings"><i class="material-icons-extended">settings</i></a>`;
+    const buttons = html`
+<a href="/settings" title="Settings" class="settings">
+  <i class="material-icons-extended">settings</i>
+</a>`;
 
     return html`
-      <a class="nav-item selected" href="/">
-        <img class="nav-item__avatar" src="${avatarUrl}" alt="Avatar of ${
-        this.user.login}" />
-        <div class="nav-item__name">${this.user.login}</div>
-        <div class="nav-item-actions">${buttons}</div>
-      </a>`;
+<a class="nav-item selected" href="/">
+  <img class="nav-item__avatar" src="${avatarUrl}"
+       alt="Avatar of ${this.user.login}" />
+  <div class="nav-item__name">${this.user.login}</div>
+  <div class="nav-item-actions">${buttons}</div>
+</a>`;
   }
 
   render() {
     return html`
-    <nav>
-      <div class="nav-item nav-title">
-        <img class="nav-item__avatar" src="/images/favicon.svg">
-        <div class="nav-item__name">Project Health</div>
-      </div>
-      ${this._userTemplate()}
-      <div class="nav-item__separator"></div>
-    <nav>`;
+<nav>
+  <div class="nav-item nav-title">
+    <img class="nav-item__avatar" src="/images/favicon.svg">
+    <div class="nav-item__name">Project Health</div>
+  </div>
+  ${this._userTemplate()}
+  <div class="nav-item__separator"></div>
+<nav>`;
   }
 }
 

--- a/src/client/public/scripts/components/row-header.ts
+++ b/src/client/public/scripts/components/row-header.ts
@@ -2,33 +2,16 @@ import {html} from '../../../../../node_modules/lit-html/lib/lit-extended.js';
 import {TemplateResult} from '../../../../../node_modules/lit-html/lit-html.js';
 import {timeToString} from '../dash/utils/time-to-string.js';
 
-import {BaseElement} from './base-element.js';
+import {BaseElement, property} from './base-element.js';
 import {DashboardRowData} from './dashboard-row.js';
 
 export class RowHeader extends BaseElement {
-  private _rowData: DashboardRowData|undefined = undefined;
-  private _extraHeaderData: TemplateResult[]|undefined = undefined;
+  @property({attribute: true}) rowData: DashboardRowData|undefined = undefined;
+  @property({attribute: true})
+  extraHeaderData: TemplateResult[]|undefined = undefined;
 
   constructor() {
     super();
-  }
-
-  get rowData(): DashboardRowData|undefined {
-    return this._rowData;
-  }
-
-  set rowData(data: DashboardRowData|undefined) {
-    this._rowData = data;
-    this.requestRender();
-  }
-
-  get extraHeaderData() {
-    return this._extraHeaderData;
-  }
-
-  set extraHeaderData(data: TemplateResult[]|undefined) {
-    this._extraHeaderData = data;
-    this.requestRender();
   }
 
   render() {
@@ -64,7 +47,7 @@ export class RowHeader extends BaseElement {
       }
     }
 
-    const data = this._rowData;
+    const data = this.rowData;
     if (!data) {
       return html``;
     }

--- a/tsconfigs/browser.json
+++ b/tsconfigs/browser.json
@@ -8,6 +8,7 @@
     "pretty": true,
     "skipLibCheck": true,
     "sourceMap": true,
+    "experimentalDecorators": true,
     "lib": [
       "es2017",
       "esnext.asynciterable",


### PR DESCRIPTION
This adds a `@property` decorator to the base class which makes it easier to write elements. By default, the decorator will call `requestRender()` when there are changes to the property. It supports an `attribute` option which allows the property to be synchronised both ways with the attribute of the identical name.