### PR TITLE
Dash data private api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8426,7 +8426,7 @@
         "abbrev": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+          "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg="
         },
         "ajv": {
           "version": "5.5.2",
@@ -8787,7 +8787,7 @@
         "ini": {
           "version": "1.3.5",
           "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+          "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc="
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",

--- a/src/client/public/scripts/dash/utils/get-data.ts
+++ b/src/client/public/scripts/dash/utils/get-data.ts
@@ -15,14 +15,36 @@ export async function getOutgoingData(): Promise<api.OutgoingDashResponse> {
   const response = await fetch(`/api/dash/outgoing${getUserLoginParam()}`, {
     credentials: 'include',
   });
-  return await response.json() as api.OutgoingDashResponse;
+
+  const fullResponse = await response.json();
+  if (fullResponse.error) {
+    throw new Error(
+        `Unable to get last known update: ${fullResponse.error.message}`);
+  }
+
+  if (!fullResponse.data) {
+    throw new Error('No data provided by JSON API.');
+  }
+
+  return fullResponse.data as api.OutgoingDashResponse;
 }
 
 export async function getIncomingData(): Promise<api.IncomingDashResponse> {
   const response = await fetch(`/api/dash/incoming${getUserLoginParam()}`, {
     credentials: 'include',
   });
-  return await response.json() as api.IncomingDashResponse;
+
+  const fullResponse = await response.json();
+  if (fullResponse.error) {
+    throw new Error(
+        `Unable to get last known update: ${fullResponse.error.message}`);
+  }
+
+  if (!fullResponse.data) {
+    throw new Error('No data provided by JSON API.');
+  }
+
+  return fullResponse.data as api.IncomingDashResponse;
 }
 
 export async function getLastKnownUpdate(): Promise<api.LastKnownResponse> {

--- a/src/server/apis/api-router/abstract-api-router.ts
+++ b/src/server/apis/api-router/abstract-api-router.ts
@@ -79,7 +79,7 @@ export abstract class AbstractAPIRouter<T extends APIRouteCallback> {
             response,
             responseHelper.error(
                 'uncaught-exception',
-                'An uncaught exception was thrown: ' + err.message));
+                `An uncaught exception was thrown: '${err.message}'`));
       }
     };
   }

--- a/src/server/apis/dash-data.ts
+++ b/src/server/apis/dash-data.ts
@@ -2,371 +2,36 @@ import * as express from 'express';
 import gql from 'graphql-tag';
 
 import * as api from '../../types/api';
-import {IncomingPullRequestsQuery, mentionedFieldsFragment, prFieldsFragment, PullRequestReviewState, reviewFieldsFragment} from '../../types/gql-types';
-import {github} from '../../utils/github';
-import {userModel, UserRecord} from '../models/userModel';
-import {getPRLastActivity, LastComment} from '../utils/get-pr-last-activity';
-import {issueHasNewActivity} from '../utils/issue-has-new-activity';
-
-import {fetchOutgoingData} from './dash-data/fetch-outgoing-data';
+import {prFieldsFragment, reviewFieldsFragment} from '../../types/gql-types';
+import {PrivateAPIRouter} from './api-router/private-api-router';
+import {handleIncomingPRRequest} from './dash-data/handle-incoming-pr-request';
+import {handleOutgoingPRRequest} from './dash-data/handle-outgoing-pr-request';
 
 /**
  * Router for the dash component.
  */
 export function getRouter(): express.Router {
-  const router = express.Router();
-  router.get('/outgoing', outgoingHandler);
-  router.get('/incoming', incomingHandler);
-  return router;
+  const dashRouter = new PrivateAPIRouter();
+  dashRouter.get('/outgoing', handleOutgoingPRRequest);
+  dashRouter.get('/incoming', handleIncomingPRRequest);
+  return dashRouter.router;
 }
 
 /**
- * Handles a response for outgoing pull requests. Available options:
- *  - ?login - string of username to view as
- *  - ?cursor - page cursor
+ * Converts a review GraphQL object to an API object.
  */
-async function outgoingHandler(req: express.Request, res: express.Response) {
-  const userRecord = await userModel.getUserRecordFromRequest(req);
-  if (!userRecord) {
-    res.sendStatus(401);
-    return;
-  }
-
-  const userData = await fetchOutgoingData(
-      userRecord,
-      req.query.login || userRecord.username,
-      req.query.cursor,
-  );
-
-  res.json(userData);
-}
-
-/**
- * Handles a response for incoming pull requests.
- */
-async function incomingHandler(req: express.Request, res: express.Response) {
-  const userRecord = await userModel.getUserRecordFromRequest(req);
-  if (!userRecord) {
-    res.sendStatus(401);
-    return;
-  }
-
-  const userData = await fetchIncomingData(
-      userRecord,
-      req.query.login || userRecord.username,
-  );
-
-  res.json(userData);
-}
-
-/**
- * Fetches incoming pull requests for user.
- */
-export async function fetchIncomingData(
-    userRecord: UserRecord,
-    dashboardLogin: string): Promise<api.IncomingDashResponse> {
-  const openPrQuery = 'is:open is:pr archived:false';
-  const reviewedQueryString =
-      `reviewed-by:${dashboardLogin} ${openPrQuery} -author:${dashboardLogin}`;
-  const reviewRequestsQueryString =
-      `review-requested:${dashboardLogin} ${openPrQuery}`;
-  const mentionsQueryString =
-      `${reviewedQueryString} mentions:${dashboardLogin}`;
-
-  const viewerPrsResult = await github().query<IncomingPullRequestsQuery>({
-    query: incomingPrsQuery,
-    variables: {
-      login: dashboardLogin,
-      reviewRequestsQueryString,
-      reviewedQueryString,
-      mentionsQueryString,
-    },
-    fetchPolicy: 'network-only',
-    context: {
-      token: userRecord.githubToken,
-    }
-  });
-
-  const incomingPrs = [];
-  // In some cases, GitHub will return a PR both in the review request list
-  // and the reviewed list. This ID set is used to ensure we don't show a PR
-  // twice.
-  const prsShown = [];
-
-  // Build a list of mentions.
-  const mentioned: Map<string, api.MentionedEvent> = new Map();
-  for (const item of viewerPrsResult.data.mentions.nodes || []) {
-    if (!item || item.__typename !== 'PullRequest') {
-      continue;
-    }
-    const mention = getLastMentioned(item, dashboardLogin);
-    if (mention) {
-      mentioned.set(item.id, mention);
-    }
-  }
-
-  let loginRecord: UserRecord|null = null;
-  let lastViewedInfo: {[issue: string]: number}|null = null;
-  if (dashboardLogin === userRecord.username) {
-    loginRecord = await userModel.getUserRecord(dashboardLogin);
-    lastViewedInfo = await userModel.getAllLastViewedInfo(dashboardLogin);
-  }
-
-  // Incoming PRs that I've reviewed.
-  for (const pr of viewerPrsResult.data.reviewed.nodes || []) {
-    if (!pr || pr.__typename !== 'PullRequest') {
-      continue;
-    }
-
-    if (pr.viewerSubscription === 'IGNORED') {
-      continue;
-    }
-
-    // Find relevant review.
-    let relevantReview: MyReviewFields|null = null;
-    if (pr.reviews && pr.reviews.nodes) {
-      // Generated gql-types is missing the proper __type field so a cast is
-      // needed.
-      relevantReview =
-          findMyRelevantReview(pr.reviews.nodes as Array<MyReviewFields|null>);
-    }
-
-    let myReview: api.Review|null = null;
-    if (relevantReview) {
-      // Cast because inner type has less strict type for __typename.
-      myReview = convertReviewFields(relevantReview as reviewFieldsFragment);
-    }
-
-    let lastComment: LastComment|null = null;
-    if (pr.comments.nodes && pr.comments.nodes.length > 0) {
-      const lastPRComment = pr.comments.nodes[0];
-      if (lastPRComment) {
-        lastComment = {
-          createdAt: new Date(lastPRComment.createdAt).getTime(),
-          author: null,
-        };
-
-        if (lastPRComment.author && lastPRComment.author.login) {
-          lastComment.author = lastPRComment.author.login;
-        }
-      }
-    }
-
-    const reviewedPr: api.PullRequest = {
-      ...convertPrFields(pr),
-      hasNewActivity: false,
-      status: {type: 'NoActionRequired'},
-    };
-
-    const prMention = mentioned.get(pr.id);
-    if (myReview) {
-      reviewedPr.events.push({type: 'MyReviewEvent', review: myReview});
-
-      if (prMention && prMention.mentionedAt > myReview.createdAt) {
-        reviewedPr.events.push(prMention);
-      }
-    } else if (prMention) {
-      reviewedPr.events.push(prMention);
-    }
-
-    // Check if there are new commits to the pull request.
-    let hasNewCommits = false;
-    if (pr.commits.nodes) {
-      const newCommits = [];
-      let additions = 0;
-      let deletions = 0;
-      let changedFiles = 0;
-      let lastPushedAt = 0;
-      let lastOid;
-      for (const node of pr.commits.nodes) {
-        if (!myReview || !node || !node.commit.pushedDate) {
-          continue;
-        }
-        const pushedAt = Date.parse(node.commit.pushedDate);
-        if (pushedAt <= myReview.createdAt) {
-          continue;
-        }
-        additions += node.commit.additions;
-        deletions += node.commit.deletions;
-        changedFiles += node.commit.changedFiles;
-        if (pushedAt > lastPushedAt) {
-          lastPushedAt = Date.parse(node.commit.pushedDate);
-          lastOid = node.commit.oid;
-        }
-        newCommits.push(node);
-      }
-
-      if (newCommits.length && relevantReview) {
-        // Commit can be null.
-        const url = relevantReview.commit ?
-            `${pr.url}/files/${relevantReview.commit.oid}..${lastOid || ''}` :
-            '';
-        reviewedPr.events.push({
-          type: 'NewCommitsEvent',
-          count: newCommits.length,
-          additions,
-          deletions,
-          changedFiles,
-          lastPushedAt,
-          url,
-        });
-        hasNewCommits = true;
-      }
-
-      reviewedPr.events = sortEvents(reviewedPr.events);
-    }
-
-    if (relevantReview &&
-        relevantReview.state === PullRequestReviewState.CHANGES_REQUESTED &&
-        !hasNewCommits) {
-      reviewedPr.status = {type: 'ChangesRequested'};
-    } else if (
-        relevantReview &&
-        relevantReview.state !== PullRequestReviewState.APPROVED) {
-      reviewedPr.status = {type: 'ApprovalRequired'};
-    }
-
-    if (lastViewedInfo && loginRecord) {
-      const lastActivity =
-          await getPRLastActivity(userRecord.username, reviewedPr, lastComment);
-      if (lastActivity) {
-        reviewedPr.hasNewActivity = await issueHasNewActivity(
-            loginRecord, lastActivity, lastViewedInfo[pr.id]);
-      }
-    }
-
-    prsShown.push(pr.id);
-    incomingPrs.push(reviewedPr);
-  }
-
-  // Incoming review requests.
-  for (const pr of viewerPrsResult.data.reviewRequests.nodes || []) {
-    if (!pr || pr.__typename !== 'PullRequest' || prsShown.includes(pr.id)) {
-      continue;
-    }
-
-    if (pr.viewerSubscription === 'IGNORED') {
-      continue;
-    }
-
-    const incomingPr: api.PullRequest = {
-      ...convertPrFields(pr),
-      status: {type: 'ReviewRequired'},
-    };
-
-    incomingPrs.push(incomingPr);
-  }
-  return {
-    timestamp: new Date().toISOString(),
-    // Sort newest first.
-    prs: sortIncomingPRs(incomingPrs),
+export function convertReviewFields(fields: reviewFieldsFragment): api.Review {
+  const review = {
+    author: '',
+    createdAt: Date.parse(fields.createdAt),
+    reviewState: fields.state,
   };
-}
 
-/**
- * Ensures events are ordered correctly.
- */
-function sortEvents(events: api.PullRequestEvent[]): api.PullRequestEvent[] {
-  const eventTime = (event: api.PullRequestEvent) => {
-    if (event.type === 'MentionedEvent') {
-      return event.mentionedAt;
-    } else if (event.type === 'NewCommitsEvent') {
-      return event.lastPushedAt;
-    } else if (event.type === 'MyReviewEvent') {
-      return event.review.createdAt;
-    } else {
-      return 0;
-    }
-  };
-  const compareEvents =
-      (a: api.PullRequestEvent, b: api.PullRequestEvent): number => {
-        const aTime = eventTime(a);
-        const bTime = eventTime(b);
-        if (aTime === 0 || bTime === 0) {
-          return 0;
-        }
-        return aTime - bTime;
-      };
-  return events.sort(compareEvents);
-}
-
-/**
- * Sorts incoming PRs into how they should be displayed.
- */
-function sortIncomingPRs(prs: api.PullRequest[]): api.PullRequest[] {
-  function getLatestEventTime(pr: api.PullRequest): number {
-    let latest = pr.createdAt;
-    for (const event of pr.events) {
-      switch (event.type) {
-        case 'NewCommitsEvent':
-          if (event.lastPushedAt > latest) {
-            latest = event.lastPushedAt;
-          }
-          break;
-        case 'MentionedEvent':
-          if (event.mentionedAt > latest) {
-            latest = event.mentionedAt;
-          }
-          break;
-        case 'MyReviewEvent':
-          // Ignore my review events. Shouldn't impact ordering since it's an
-          // event generated by you.
-          break;
-        default:
-          break;
-      }
-    }
-    return latest;
+  if (fields.author && fields.author.__typename === 'User') {
+    review.author = fields.author.login;
   }
 
-  // Sort descending by latest event time.
-  const timeSorted =
-      prs.sort((a, b) => getLatestEventTime(b) - getLatestEventTime(a));
-
-  const notActionableStatuses = [
-    'UnknownStatus',
-    'ChangesRequested',
-    'NoActionRequired',
-    'NewActivity',
-    'StatusChecksPending'
-  ];
-  const actionable = [];
-  const notActionable = [];
-  // Add actionable PRs.
-  for (const pr of timeSorted) {
-    if (notActionableStatuses.includes(pr.status.type)) {
-      notActionable.push(pr);
-    } else {
-      actionable.push(pr);
-    }
-  }
-  return actionable.concat(notActionable);
-}
-
-
-
-type MyReviewFields = reviewFieldsFragment&{commit: {oid: string}};
-
-function findMyRelevantReview(reviews: Array<MyReviewFields|null>):
-    MyReviewFields|null {
-  let relevantReview: MyReviewFields|null = null;
-  for (let i = reviews.length - 1; i >= 0; i--) {
-    const nextReview = reviews[i];
-    // Pending reviews have not been sent yet.
-    if (!relevantReview && nextReview &&
-        nextReview.state !== PullRequestReviewState.PENDING) {
-      relevantReview = nextReview;
-    } else if (
-        relevantReview &&
-        relevantReview.state === PullRequestReviewState.COMMENTED &&
-        nextReview &&
-        (nextReview.state === PullRequestReviewState.APPROVED ||
-         nextReview.state === PullRequestReviewState.CHANGES_REQUESTED)) {
-      // Use last approved/changes requested if it exists.
-      relevantReview = nextReview;
-    }
-  }
-  return relevantReview;
+  return review;
 }
 
 /**
@@ -394,74 +59,6 @@ export function convertPrFields(fields: prFieldsFragment): api.PullRequest {
   }
 
   return pr;
-}
-
-/**
- * Converts a review GraphQL object to an API object.
- */
-export function convertReviewFields(fields: reviewFieldsFragment): api.Review {
-  const review = {
-    author: '',
-    createdAt: Date.parse(fields.createdAt),
-    reviewState: fields.state,
-  };
-
-  if (fields.author && fields.author.__typename === 'User') {
-    review.author = fields.author.login;
-  }
-
-  return review;
-}
-
-function getLastMentioned(pullRequest: mentionedFieldsFragment, login: string):
-    api.MentionedEvent|null {
-  let latest = null;
-
-  for (const comment of pullRequest.comments.nodes || []) {
-    if (!comment || !comment.bodyText.includes(`@${login}`)) {
-      continue;
-    }
-    if (!latest || comment.createdAt > latest.createdAt) {
-      latest = comment;
-    }
-  }
-
-  if (pullRequest.reviews) {
-    for (const review of pullRequest.reviews.nodes || []) {
-      if (!review) {
-        continue;
-      }
-      if (review.bodyText.includes(`@${login}`) &&
-          (!latest || review.createdAt > latest.createdAt)) {
-        latest = review;
-      }
-
-      for (const comment of review.comments.nodes || []) {
-        if (!comment || !comment.bodyText.includes(`@${login}`)) {
-          continue;
-        }
-        if (!latest || comment.createdAt > latest.createdAt) {
-          latest = comment;
-        }
-      }
-    }
-  }
-
-  if (!latest) {
-    return null;
-  }
-
-  let text = latest.bodyText;
-  if (text.length > 300) {
-    text = text.substr(0, 300) + '…';
-  }
-
-  return {
-    type: 'MentionedEvent',
-    text,
-    mentionedAt: Date.parse(latest.createdAt),
-    url: latest.url,
-  };
 }
 
 const reviewFragment = gql`
@@ -580,7 +177,7 @@ fragment statusFields on PullRequest {
 }
 `;
 
-const incomingPrsQuery = gql`
+export const incomingPrsQuery = gql`
 query IncomingPullRequests($login: String!, $reviewRequestsQueryString: String!, $reviewedQueryString: String!, $mentionsQueryString: String!) {
   reviewRequests: search(type: ISSUE, query: $reviewRequestsQueryString, last: 20) {
     nodes {

--- a/src/server/apis/dash-data/handle-incoming-pr-request.ts
+++ b/src/server/apis/dash-data/handle-incoming-pr-request.ts
@@ -1,0 +1,371 @@
+import * as express from 'express';
+
+import * as api from '../../../types/api';
+import {IncomingPullRequestsQuery, mentionedFieldsFragment, PullRequestReviewState, reviewFieldsFragment} from '../../../types/gql-types';
+import {github} from '../../../utils/github';
+import {userModel, UserRecord} from '../../models/userModel';
+import {getPRLastActivity, LastComment} from '../../utils/get-pr-last-activity';
+import {issueHasNewActivity} from '../../utils/issue-has-new-activity';
+import {DataAPIResponse} from '../api-router/abstract-api-router';
+import * as responseHelper from '../api-router/response-helper';
+import {convertPrFields, convertReviewFields, incomingPrsQuery} from '../dash-data';
+
+type MyReviewFields = reviewFieldsFragment&{commit: {oid: string}};
+
+/**
+ * Handles a response for incoming pull requests.
+ */
+export async function handleIncomingPRRequest(
+    request: express.Request, userRecord: UserRecord):
+    Promise<DataAPIResponse<api.IncomingDashResponse>> {
+  const dashLogin = request.query.login || userRecord.username;
+  const openPrQuery = 'is:open is:pr archived:false';
+  const reviewedQueryString =
+      `reviewed-by:${dashLogin} ${openPrQuery} -author:${dashLogin}`;
+  const reviewRequestsQueryString =
+      `review-requested:${dashLogin} ${openPrQuery}`;
+  const mentionsQueryString = `${reviewedQueryString} mentions:${dashLogin}`;
+
+  const viewerPrsResult = await github().query<IncomingPullRequestsQuery>({
+    query: incomingPrsQuery,
+    variables: {
+      login: dashLogin,
+      reviewRequestsQueryString,
+      reviewedQueryString,
+      mentionsQueryString,
+    },
+    fetchPolicy: 'network-only',
+    context: {
+      token: userRecord.githubToken,
+    }
+  });
+
+  const incomingPrs = [];
+  // In some cases, GitHub will return a PR both in the review request list
+  // and the reviewed list. This ID set is used to ensure we don't show a PR
+  // twice.
+  const prsShown = [];
+
+  // Build a list of mentions.
+  const mentioned: Map<string, api.MentionedEvent> = new Map();
+  for (const item of viewerPrsResult.data.mentions.nodes || []) {
+    if (!item || item.__typename !== 'PullRequest') {
+      continue;
+    }
+    const mention = getLastMentioned(item, dashLogin);
+    if (mention) {
+      mentioned.set(item.id, mention);
+    }
+  }
+
+  let loginRecord: UserRecord|null = null;
+  let lastViewedInfo: {[issue: string]: number}|null = null;
+  if (dashLogin === userRecord.username) {
+    loginRecord = await userModel.getUserRecord(dashLogin);
+    lastViewedInfo = await userModel.getAllLastViewedInfo(dashLogin);
+  }
+
+  // Incoming PRs that I've reviewed.
+  for (const pr of viewerPrsResult.data.reviewed.nodes || []) {
+    if (!pr || pr.__typename !== 'PullRequest') {
+      continue;
+    }
+
+    if (pr.viewerSubscription === 'IGNORED') {
+      continue;
+    }
+
+    // Find relevant review.
+    let relevantReview: MyReviewFields|null = null;
+    if (pr.reviews && pr.reviews.nodes) {
+      // Generated gql-types is missing the proper __type field so a cast is
+      // needed.
+      relevantReview =
+          findMyRelevantReview(pr.reviews.nodes as Array<MyReviewFields|null>);
+    }
+
+    let myReview: api.Review|null = null;
+    if (relevantReview) {
+      // Cast because inner type has less strict type for __typename.
+      myReview = convertReviewFields(relevantReview as reviewFieldsFragment);
+    }
+
+    let lastComment: LastComment|null = null;
+    if (pr.comments.nodes && pr.comments.nodes.length > 0) {
+      const lastPRComment = pr.comments.nodes[0];
+      if (lastPRComment) {
+        lastComment = {
+          createdAt: new Date(lastPRComment.createdAt).getTime(),
+          author: null,
+        };
+
+        if (lastPRComment.author && lastPRComment.author.login) {
+          lastComment.author = lastPRComment.author.login;
+        }
+      }
+    }
+
+    const reviewedPr: api.PullRequest = {
+      ...convertPrFields(pr),
+      hasNewActivity: false,
+      status: {type: 'NoActionRequired'},
+    };
+
+    const prMention = mentioned.get(pr.id);
+    if (myReview) {
+      reviewedPr.events.push({type: 'MyReviewEvent', review: myReview});
+
+      if (prMention && prMention.mentionedAt > myReview.createdAt) {
+        reviewedPr.events.push(prMention);
+      }
+    } else if (prMention) {
+      reviewedPr.events.push(prMention);
+    }
+
+    // Check if there are new commits to the pull request.
+    let hasNewCommits = false;
+    if (pr.commits.nodes) {
+      const newCommits = [];
+      let additions = 0;
+      let deletions = 0;
+      let changedFiles = 0;
+      let lastPushedAt = 0;
+      let lastOid;
+      for (const node of pr.commits.nodes) {
+        if (!myReview || !node || !node.commit.pushedDate) {
+          continue;
+        }
+        const pushedAt = Date.parse(node.commit.pushedDate);
+        if (pushedAt <= myReview.createdAt) {
+          continue;
+        }
+        additions += node.commit.additions;
+        deletions += node.commit.deletions;
+        changedFiles += node.commit.changedFiles;
+        if (pushedAt > lastPushedAt) {
+          lastPushedAt = Date.parse(node.commit.pushedDate);
+          lastOid = node.commit.oid;
+        }
+        newCommits.push(node);
+      }
+
+      if (newCommits.length && relevantReview) {
+        // Commit can be null.
+        const url = relevantReview.commit ?
+            `${pr.url}/files/${relevantReview.commit.oid}..${lastOid || ''}` :
+            '';
+        reviewedPr.events.push({
+          type: 'NewCommitsEvent',
+          count: newCommits.length,
+          additions,
+          deletions,
+          changedFiles,
+          lastPushedAt,
+          url,
+        });
+        hasNewCommits = true;
+      }
+
+      reviewedPr.events = sortEvents(reviewedPr.events);
+    }
+
+    if (relevantReview &&
+        relevantReview.state === PullRequestReviewState.CHANGES_REQUESTED &&
+        !hasNewCommits) {
+      reviewedPr.status = {type: 'ChangesRequested'};
+    } else if (
+        relevantReview &&
+        relevantReview.state !== PullRequestReviewState.APPROVED) {
+      reviewedPr.status = {type: 'ApprovalRequired'};
+    }
+
+    if (lastViewedInfo && loginRecord) {
+      const lastActivity =
+          await getPRLastActivity(userRecord.username, reviewedPr, lastComment);
+      if (lastActivity) {
+        reviewedPr.hasNewActivity = await issueHasNewActivity(
+            loginRecord, lastActivity, lastViewedInfo[pr.id]);
+      }
+    }
+
+    prsShown.push(pr.id);
+    incomingPrs.push(reviewedPr);
+  }
+
+  // Incoming review requests.
+  for (const pr of viewerPrsResult.data.reviewRequests.nodes || []) {
+    if (!pr || pr.__typename !== 'PullRequest' || prsShown.includes(pr.id)) {
+      continue;
+    }
+
+    if (pr.viewerSubscription === 'IGNORED') {
+      continue;
+    }
+
+    const incomingPr: api.PullRequest = {
+      ...convertPrFields(pr),
+      status: {type: 'ReviewRequired'},
+    };
+
+    incomingPrs.push(incomingPr);
+  }
+
+  return responseHelper.data({
+    timestamp: new Date().toISOString(),
+    // Sort newest first.
+    prs: sortIncomingPRs(incomingPrs),
+  });
+}
+
+function getLastMentioned(pullRequest: mentionedFieldsFragment, login: string):
+    api.MentionedEvent|null {
+  let latest = null;
+
+  for (const comment of pullRequest.comments.nodes || []) {
+    if (!comment || !comment.bodyText.includes(`@${login}`)) {
+      continue;
+    }
+    if (!latest || comment.createdAt > latest.createdAt) {
+      latest = comment;
+    }
+  }
+
+  if (pullRequest.reviews) {
+    for (const review of pullRequest.reviews.nodes || []) {
+      if (!review) {
+        continue;
+      }
+      if (review.bodyText.includes(`@${login}`) &&
+          (!latest || review.createdAt > latest.createdAt)) {
+        latest = review;
+      }
+
+      for (const comment of review.comments.nodes || []) {
+        if (!comment || !comment.bodyText.includes(`@${login}`)) {
+          continue;
+        }
+        if (!latest || comment.createdAt > latest.createdAt) {
+          latest = comment;
+        }
+      }
+    }
+  }
+
+  if (!latest) {
+    return null;
+  }
+
+  let text = latest.bodyText;
+  if (text.length > 300) {
+    text = text.substr(0, 300) + '…';
+  }
+
+  return {
+    type: 'MentionedEvent',
+    text,
+    mentionedAt: Date.parse(latest.createdAt),
+    url: latest.url,
+  };
+}
+
+function findMyRelevantReview(reviews: Array<MyReviewFields|null>):
+    MyReviewFields|null {
+  let relevantReview: MyReviewFields|null = null;
+  for (let i = reviews.length - 1; i >= 0; i--) {
+    const nextReview = reviews[i];
+    // Pending reviews have not been sent yet.
+    if (!relevantReview && nextReview &&
+        nextReview.state !== PullRequestReviewState.PENDING) {
+      relevantReview = nextReview;
+    } else if (
+        relevantReview &&
+        relevantReview.state === PullRequestReviewState.COMMENTED &&
+        nextReview &&
+        (nextReview.state === PullRequestReviewState.APPROVED ||
+         nextReview.state === PullRequestReviewState.CHANGES_REQUESTED)) {
+      // Use last approved/changes requested if it exists.
+      relevantReview = nextReview;
+    }
+  }
+  return relevantReview;
+}
+
+/**
+ * Ensures events are ordered correctly.
+ */
+function sortEvents(events: api.PullRequestEvent[]): api.PullRequestEvent[] {
+  const eventTime = (event: api.PullRequestEvent) => {
+    if (event.type === 'MentionedEvent') {
+      return event.mentionedAt;
+    } else if (event.type === 'NewCommitsEvent') {
+      return event.lastPushedAt;
+    } else if (event.type === 'MyReviewEvent') {
+      return event.review.createdAt;
+    } else {
+      return 0;
+    }
+  };
+  const compareEvents =
+      (a: api.PullRequestEvent, b: api.PullRequestEvent): number => {
+        const aTime = eventTime(a);
+        const bTime = eventTime(b);
+        if (aTime === 0 || bTime === 0) {
+          return 0;
+        }
+        return aTime - bTime;
+      };
+  return events.sort(compareEvents);
+}
+
+/**
+ * Sorts incoming PRs into how they should be displayed.
+ */
+function sortIncomingPRs(prs: api.PullRequest[]): api.PullRequest[] {
+  function getLatestEventTime(pr: api.PullRequest): number {
+    let latest = pr.createdAt;
+    for (const event of pr.events) {
+      switch (event.type) {
+        case 'NewCommitsEvent':
+          if (event.lastPushedAt > latest) {
+            latest = event.lastPushedAt;
+          }
+          break;
+        case 'MentionedEvent':
+          if (event.mentionedAt > latest) {
+            latest = event.mentionedAt;
+          }
+          break;
+        case 'MyReviewEvent':
+          // Ignore my review events. Shouldn't impact ordering since it's an
+          // event generated by you.
+          break;
+        default:
+          break;
+      }
+    }
+    return latest;
+  }
+
+  // Sort descending by latest event time.
+  const timeSorted =
+      prs.sort((a, b) => getLatestEventTime(b) - getLatestEventTime(a));
+
+  const notActionableStatuses = [
+    'UnknownStatus',
+    'ChangesRequested',
+    'NoActionRequired',
+    'NewActivity',
+    'StatusChecksPending'
+  ];
+  const actionable = [];
+  const notActionable = [];
+  // Add actionable PRs.
+  for (const pr of timeSorted) {
+    if (notActionableStatuses.includes(pr.status.type)) {
+      notActionable.push(pr);
+    } else {
+      actionable.push(pr);
+    }
+  }
+  return actionable.concat(notActionable);
+}

--- a/src/test/server/apis/incoming-prs-test.ts
+++ b/src/test/server/apis/incoming-prs-test.ts
@@ -1,10 +1,11 @@
 import anyTest, {TestInterface} from 'ava';
 
-import {fetchIncomingData} from '../../../server/apis/dash-data';
+import {handleIncomingPRRequest} from '../../../server/apis/dash-data/handle-incoming-pr-request';
 import {IncomingDashResponse, PullRequest} from '../../../types/api';
 import {PullRequestReviewState} from '../../../types/gql-types';
 import {initFirestore} from '../../../utils/firestore';
 import {initGithub} from '../../../utils/github';
+import {newFakeRequest} from '../../utils/newFakeRequest';
 import {newFakeUserRecord} from '../../utils/newFakeUserRecord';
 import {startTestReplayServer} from '../../utils/replay-server';
 
@@ -27,17 +28,18 @@ test.beforeEach(async (t) => {
   initGithub(url, url);
 
   const userRecord = newFakeUserRecord();
-  const data = await fetchIncomingData(userRecord, 'project-health1');
+  userRecord.username = 'project-health1';
+  const response = await handleIncomingPRRequest(newFakeRequest(), userRecord);
   server.close();
 
   const prsById = new Map();
-  for (const pr of data.prs) {
+  for (const pr of response.data.prs) {
     prsById.set(
         pr.url.replace('https://github.com/project-health1/repo/pull/', ''),
         pr);
   }
   t.context = {
-    data,
+    data: response.data,
     prsById,
   };
 });

--- a/src/test/server/apis/outgoing-prs-2-test.ts
+++ b/src/test/server/apis/outgoing-prs-2-test.ts
@@ -1,10 +1,11 @@
 import anyTest, {TestInterface} from 'ava';
 
-import {fetchOutgoingData} from '../../../server/apis/dash-data/fetch-outgoing-data';
+import {handleOutgoingPRRequest} from '../../../server/apis/dash-data/handle-outgoing-pr-request';
 import {OutgoingDashResponse, OutgoingPullRequest} from '../../../types/api';
 import {PullRequestReviewState} from '../../../types/gql-types';
 import {initFirestore} from '../../../utils/firestore';
 import {initGithub} from '../../../utils/github';
+import {newFakeRequest} from '../../utils/newFakeRequest';
 import {newFakeUserRecord} from '../../utils/newFakeUserRecord';
 import {startTestReplayServer} from '../../utils/replay-server';
 
@@ -27,18 +28,18 @@ test.beforeEach(async (t) => {
   initGithub(url, url);
 
   const userRecord = newFakeUserRecord();
-
-  const data = await fetchOutgoingData(userRecord, 'project-health2');
+  userRecord.username = 'project-health2';
+  const reponse = await handleOutgoingPRRequest(newFakeRequest(), userRecord);
   server.close();
 
   const prsById = new Map();
-  for (const pr of data.prs) {
+  for (const pr of reponse.data.prs) {
     prsById.set(
         pr.url.replace('https://github.com/project-health1/repo/pull/', ''),
         pr);
   }
   t.context = {
-    data,
+    data: reponse.data,
     prsById,
   };
 });

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -73,7 +73,13 @@ class GitHub {
             console.warn(
                 'Failed to query GitHub for:', options.query.loc.source);
           }
-          throw e;
+
+          if (e.networkError && e.networkError.result &&
+              e.networkError.result.message) {
+            throw new Error(e.networkError.result.message);
+          } else {
+            throw e;
+          }
         }
       }
     }


### PR DESCRIPTION
Whatever happened last night, there were a few things that could have been better:

1. The errors shouldn't have been uncaught. This PR moved the dash data to the private api router which will catch errors.
1. I pulled out the incoming PR into a seperate file.
1. I've tried to pull out GitHub's error instead of letting Apollo throw a network error.