### PR TITLE
Adding a settings models

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -933,12 +933,12 @@
     "@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+      "integrity": "sha1-TIVzDlm5ofHzSQR9vyQpYDS7JzU="
     },
     "@protobufjs/codegen": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+      "integrity": "sha1-fvN/DQEPsCitGtWXIuUG2SYoFcs="
     },
     "@protobufjs/eventemitter": {
       "version": "1.1.0",
@@ -1095,7 +1095,7 @@
     "@types/long": {
       "version": "3.0.32",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-3.0.32.tgz",
-      "integrity": "sha512-ZXyOOm83p7X8p3s0IYM3VeueNmHpkk/yMlP8CLeOnEcu6hIwPH7YjZBvhQkR0ZFS2DqZAxKtJ/M5fcuv3OU5BA=="
+      "integrity": "sha1-9OWvMenpsZbY5fyopeLiCqPWC2k="
     },
     "@types/mime": {
       "version": "2.0.0",
@@ -2864,7 +2864,7 @@
     "bun": {
       "version": "0.0.12",
       "resolved": "https://registry.npmjs.org/bun/-/bun-0.0.12.tgz",
-      "integrity": "sha512-Toms18J9DqnT+IfWkwxVTB2EaBprHvjlMWrTIsfX4xbu3ZBqVBwrERU0em1IgtRe04wT+wJxMlKHZok24hrcSQ==",
+      "integrity": "sha1-1U+uafiVVX8nVCO8FLQEAwsgpfw=",
       "requires": {
         "readable-stream": "1.0.34"
       },
@@ -8241,7 +8241,7 @@
         "abbrev": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-          "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg="
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
         },
         "ajv": {
           "version": "5.5.2",
@@ -8602,7 +8602,7 @@
         "ini": {
           "version": "1.3.5",
           "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-          "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc="
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
@@ -10908,6 +10908,11 @@
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
+    },
+    "jsonschema": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
+      "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
     },
     "jsonwebtoken": {
       "version": "8.2.1",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "graphql": "^0.13.2",
     "graphql-tag": "^2.6.1",
     "json5": "^1.0.1",
+    "jsonschema": "^1.2.4",
     "jsonwebtoken": "^8.2.1",
     "lit-html": "^0.9.0",
     "node-fetch": "^2.1.2",

--- a/src/client/public/scripts/pages/org/config.ts
+++ b/src/client/public/scripts/pages/org/config.ts
@@ -26,7 +26,6 @@ class OrgConfig extends BaseElement {
     if (urlParams) {
       const splitParams = urlParams.split('/');
       this.orgName = splitParams[0];
-      console.log('orgName: ', this.orgName);
     }
     this.getLatestConfig();
   }

--- a/src/server/apis/org-config.ts
+++ b/src/server/apis/org-config.ts
@@ -50,7 +50,7 @@ export async function handleSaveConfigRequest(
     return responseHelper.error('unable-to-save', err.message);
   }
 
-  settings.configChanged(orgName, JSON5.parse(newSettings));
+  settings.onChange(orgName, JSON5.parse(newSettings));
 
   return responseHelper.data<GenericStatusResponse>({
     status: 'ok',

--- a/src/server/apis/org-config.ts
+++ b/src/server/apis/org-config.ts
@@ -1,7 +1,9 @@
 import * as express from 'express';
+import * as JSON5 from 'json5';
 
 import {OrgSettings} from '../../types/api';
 import {GenericStatusResponse} from '../../types/api';
+import {settings} from '../controllers/github-app-settings';
 import {settingsModel} from '../models/settingsModel';
 import {UserRecord} from '../models/userModel';
 
@@ -47,6 +49,8 @@ export async function handleSaveConfigRequest(
   } catch (err) {
     return responseHelper.error('unable-to-save', err.message);
   }
+
+  settings.configChanged(orgName, JSON5.parse(newSettings));
 
   return responseHelper.data<GenericStatusResponse>({
     status: 'ok',

--- a/src/server/controllers/github-app-settings.ts
+++ b/src/server/controllers/github-app-settings.ts
@@ -1,0 +1,110 @@
+import * as fse from 'fs-extra';
+import {validate} from 'jsonschema';
+import * as path from 'path';
+
+import {githubAppModel, GithubRepo} from '../models/githubAppModel';
+
+// TODO: How should this be configured
+type AvailableIssueTypes = boolean;
+
+interface SettingsModuleConfig {
+  default: AvailableIssueTypes;
+  description: string;
+  type: string;
+}
+
+export interface SettingsModule {
+  config(): {[key: string]: SettingsModuleConfig};
+
+  // tslint:disable-next-line:no-any
+  run: (settingConfig: any, repos: GithubRepo[]) => Promise<void>;
+}
+
+class Settings {
+  private moduleKeys: Set<string>;
+  private settingsModules: SettingsModule[];
+  private initialised: boolean;
+
+  constructor() {
+    this.initialised = false;
+    this.settingsModules = [];
+    this.moduleKeys = new Set();
+  }
+
+  addSettingsModule(module: SettingsModule) {
+    const configKeys = Object.keys(module.config());
+    for (const key of configKeys) {
+      if (this.moduleKeys.has(key)) {
+        throw new Error('Duplicate SettingsModule keys found: ' + key);
+      }
+
+      this.moduleKeys.add(key);
+    }
+
+    this.settingsModules.push(module);
+  }
+
+  private async init() {
+    const settingsDir = path.join(__dirname, 'settings');
+    // Autoloads priority issues
+    const files = await fse.readdir(settingsDir);
+    for (const file of files) {
+      if (path.extname(file) === '.js') {
+import(path.join(settingsDir, file));
+      }
+    }
+
+    this.initialised = true;
+  }
+
+  // tslint:disable-next-line:no-any
+  async validate(settings: any) {
+    if (!this.initialised) {
+      await this.init();
+    }
+
+    for (const module of this.settingsModules) {
+      const config = module.config();
+      for (const key of Object.keys(config)) {
+        if (key in settings) {
+          // tslint:disable-next-line:no-any
+          const report = validate(settings[key] as any, config[key]);
+          if (!report.valid) {
+            // This ensures the problem key is included in the error message.
+            throw new Error(`"${key}" ${report.errors[0]}.`);
+          }
+        }
+      }
+    }
+  }
+
+  async configChanged(
+      orgOrUser: string,
+      userSettings: {[key: string]: AvailableIssueTypes}) {
+    if (!this.initialised) {
+      await this.init();
+    }
+
+    const repos = await githubAppModel.getRepos(orgOrUser);
+    if (repos.length === 0) {
+      // No  repos, so nothing to do.
+      return;
+    }
+
+    for (const module of this.settingsModules) {
+      const config = module.config();
+      const reducedSettings: {[key: string]: AvailableIssueTypes} = {};
+      for (const key of Object.keys(config)) {
+        if (userSettings[key]) {
+          reducedSettings[key] = userSettings[key];
+        } else {
+          reducedSettings[key] = config[key].default;
+        }
+      }
+      await module.run(reducedSettings, repos);
+    }
+  }
+}
+
+
+export const settings = new Settings();

--- a/src/server/controllers/github-app-settings.ts
+++ b/src/server/controllers/github-app-settings.ts
@@ -33,7 +33,6 @@ class Settings {
   loadAppPlugins() {
     const settingsDir = path.join(__dirname, 'settings');
 
-    // Autoloads priority issues
     const files = fse.readdirSync(settingsDir);
     for (const file of files) {
       if (path.extname(file) === '.js') {

--- a/src/server/controllers/settings/priority-issues.ts
+++ b/src/server/controllers/settings/priority-issues.ts
@@ -6,7 +6,7 @@ export interface PluginSetting {
   'issues.priorityIssues': boolean;
 }
 
-class PriorityIssueSetting implements AppPlugin {
+class PriorityIssuePlugin implements AppPlugin {
   config() {
     return {
       'issues.priorityIssues': {

--- a/src/server/controllers/settings/priority-issues.ts
+++ b/src/server/controllers/settings/priority-issues.ts
@@ -1,0 +1,20 @@
+import {GithubRepo} from '../../models/githubAppModel';
+import {settings, SettingsModule} from '../github-app-settings';
+
+class PriorityIssueSetting implements SettingsModule {
+  config() {
+    return {
+      'issues.priorityIssues': {
+        default: false,
+        description: 'Adds P0 - P3 labels in all repo\'s',
+        type: 'boolean',
+      },
+    };
+  }
+  // tslint:disable-next-line:no-any
+  async run(setting: any, repos: GithubRepo[]) {
+    console.log('Priority Issue.: ', setting, 'on: ', repos);
+  }
+}
+
+settings.addSettingsModule(new PriorityIssueSetting());

--- a/src/server/controllers/settings/priority-issues.ts
+++ b/src/server/controllers/settings/priority-issues.ts
@@ -24,4 +24,4 @@ class PriorityIssuePlugin implements AppPlugin {
   }
 }
 
-settings.registerPlugin(new PriorityIssueSetting());
+settings.registerPlugin(new PriorityIssuePlugin());

--- a/src/server/controllers/settings/priority-issues.ts
+++ b/src/server/controllers/settings/priority-issues.ts
@@ -1,7 +1,12 @@
 import {GithubRepo} from '../../models/githubAppModel';
-import {settings, SettingsModule} from '../github-app-settings';
+import {AppPlugin, settings} from '../github-app-settings';
 
-class PriorityIssueSetting implements SettingsModule {
+// TODO: Conditional types might allow us to define this from config()
+export interface PluginSetting {
+  'issues.priorityIssues': boolean;
+}
+
+class PriorityIssueSetting implements AppPlugin {
   config() {
     return {
       'issues.priorityIssues': {
@@ -11,10 +16,12 @@ class PriorityIssueSetting implements SettingsModule {
       },
     };
   }
-  // tslint:disable-next-line:no-any
-  async run(setting: any, repos: GithubRepo[]) {
+
+  async settingsChanged<PluginSetting>(
+      setting: PluginSetting,
+      repos: GithubRepo[]) {
     console.log('Priority Issue.: ', setting, 'on: ', repos);
   }
 }
 
-settings.addSettingsModule(new PriorityIssueSetting());
+settings.registerPlugin(new PriorityIssueSetting());

--- a/src/server/models/githubAppModel.ts
+++ b/src/server/models/githubAppModel.ts
@@ -72,7 +72,7 @@ class GithubAppsModel {
     }
   }
 
-  async getInstallationByName(orgOrUser: string):
+  async getInstallationByOrgOrUserName(orgOrUser: string):
       Promise<GithubAppInstall|null> {
     const repoDocSnapshot = await firestore()
                                 .collection(GITHUB_APP_COLLECTION_NAME)
@@ -82,6 +82,24 @@ class GithubAppsModel {
       return null;
     }
     return repoDocSnapshot.data() as GithubAppInstall;
+  }
+
+  async getRepos(orgOrUser: string): Promise<GithubRepo[]> {
+    const repoDocSnapshot = await firestore()
+                                .collection(GITHUB_APP_COLLECTION_NAME)
+                                .doc(orgOrUser)
+                                .collection(GITHUB_APP_REPO_COLLECTION_NAME)
+                                .get();
+
+    const repos: GithubRepo[] = [];
+    for (const doc of repoDocSnapshot.docs) {
+      const data = doc.data();
+      if (!data) {
+        continue;
+      }
+      repos.push(data as GithubRepo);
+    }
+    return repos;
   }
 }
 

--- a/src/server/models/settingsModel.ts
+++ b/src/server/models/settingsModel.ts
@@ -77,7 +77,7 @@ class SettingsModel {
       throw new Error('Settings are not valid JSON5.');
     }
 
-    await settings.validate(parsedValues);
+    settings.validate(parsedValues);
 
     const orgDocRef = await firestore()
                           .collection(ORG_SETTINGS_COLLECTION_NAME)

--- a/src/server/models/settingsModel.ts
+++ b/src/server/models/settingsModel.ts
@@ -3,6 +3,7 @@ import * as JSON5 from 'json5';
 import {OrgSettings} from '../../types/api';
 import {firestore} from '../../utils/firestore';
 import {github} from '../../utils/github';
+import {settings} from '../controllers/github-app-settings';
 import {generateGithubAppToken} from '../utils/generate-github-app-token';
 
 import {githubAppModel} from './githubAppModel';
@@ -19,7 +20,7 @@ class SettingsModel {
     }
 
     const installDetails =
-        await githubAppModel.getInstallationByName(orgOrUser);
+        await githubAppModel.getInstallationByOrgOrUserName(orgOrUser);
     if (!installDetails) {
       throw new Error(
           `The GitHub application is not installed for '${orgOrUser}'`);
@@ -69,11 +70,14 @@ class SettingsModel {
       throw new Error('User does not have permission to access this data.');
     }
 
+    let parsedValues;
     try {
-      JSON5.parse(newSettings);
+      parsedValues = JSON5.parse(newSettings);
     } catch (e) {
       throw new Error('Settings are not valid JSON5.');
     }
+
+    await settings.validate(parsedValues);
 
     const orgDocRef = await firestore()
                           .collection(ORG_SETTINGS_COLLECTION_NAME)

--- a/src/test/server/models/settingsModel-test.ts
+++ b/src/test/server/models/settingsModel-test.ts
@@ -42,7 +42,7 @@ test.serial(
 test.serial(
     '[settingsModel]: should throw when accessing another users account',
     async (t) => {
-      t.context.sandbox.stub(githubAppModel, 'getInstallationByName')
+      t.context.sandbox.stub(githubAppModel, 'getInstallationByOrgOrUserName')
           .callsFake(() => {
             return {
               installationId: 0,
@@ -68,7 +68,7 @@ test.serial(
 
 test.serial(
     '[settingsModel]: should throw if the app is not installed', async (t) => {
-      t.context.sandbox.stub(githubAppModel, 'getInstallationByName')
+      t.context.sandbox.stub(githubAppModel, 'getInstallationByOrgOrUserName')
           .callsFake(() => {
             return null;
           });
@@ -81,7 +81,7 @@ test.serial(
 test.serial(
     '[settingsModel]: should throw when user is not an active member',
     async (t) => {
-      t.context.sandbox.stub(githubAppModel, 'getInstallationByName')
+      t.context.sandbox.stub(githubAppModel, 'getInstallationByOrgOrUserName')
           .callsFake(() => {
             return {
               installationId: 0,
@@ -126,7 +126,7 @@ test.serial(
 
 test.serial(
     '[settingsModel]: should set and return orgs settings', async (t) => {
-      t.context.sandbox.stub(githubAppModel, 'getInstallationByName')
+      t.context.sandbox.stub(githubAppModel, 'getInstallationByOrgOrUserName')
           .callsFake(() => {
             return {
               installationId: 0,
@@ -166,7 +166,7 @@ test.serial(
 test.serial(
     '[settingsModel]: should update org settings and add editors',
     async (t) => {
-      t.context.sandbox.stub(githubAppModel, 'getInstallationByName')
+      t.context.sandbox.stub(githubAppModel, 'getInstallationByOrgOrUserName')
           .callsFake(() => {
             return {
               installationId: 0,
@@ -216,7 +216,7 @@ test.serial(
 test.serial(
     '[settingsModel]: should throw when attempting to set settings on an org without admin rights',
     async (t) => {
-      t.context.sandbox.stub(githubAppModel, 'getInstallationByName')
+      t.context.sandbox.stub(githubAppModel, 'getInstallationByOrgOrUserName')
           .callsFake(() => {
             return {
               installationId: 0,
@@ -247,7 +247,7 @@ test.serial(
 test.serial(
     '[settingsModel]: should throw when attempting to save non-JSON data',
     async (t) => {
-      t.context.sandbox.stub(githubAppModel, 'getInstallationByName')
+      t.context.sandbox.stub(githubAppModel, 'getInstallationByOrgOrUserName')
           .callsFake(() => {
             return {
               installationId: 0,
@@ -278,7 +278,7 @@ test.serial(
 test.serial(
     '[settingsModel]: should not set when user is not an active member',
     async (t) => {
-      t.context.sandbox.stub(githubAppModel, 'getInstallationByName')
+      t.context.sandbox.stub(githubAppModel, 'getInstallationByOrgOrUserName')
           .callsFake(() => {
             return {
               installationId: 0,


### PR DESCRIPTION
Idea is - when a settings file is changed (at the moment the org config file is changed / updated) calling `installationSettingsChange()` will step through an orgs repo's and setup any settings accordingly

This works by running `initSettings()` is needed which will import all files under `server/controllers/settings/` which will add themselves as settings, passing in a key and an instance of a `Setting` class.

After this, `installationSettingsChange()` will look at the users config and call `run()` on any setting it is aware of.

At the moment I'm using `any` for the actual setting as a user can define anything they want, but perhaps we should be using what we expect in the Setting panel?

For example, this will currently save:

```
{
  "issues.priorityIssues": {
    "value": true
  }
}
```

But the expected value is:

```
{
  "issues.priorityIssues": true
}
```

I'm not sure what is best practice for this / how we should support it.
