### PR TITLE
Abort inflight fetches when switching pages

### DIFF
--- a/src/client/public/scripts/pages/repo.ts
+++ b/src/client/public/scripts/pages/repo.ts
@@ -56,7 +56,7 @@ class RepoPage extends BaseElement {
    * This wraps fetch to keep track of pending fetches so they can be aborted if
    * necessary.
    */
-  private async cancelableFetch(input: RequestInfo): Promise<Response|null> {
+  private async abortableFetch(input: RequestInfo): Promise<Response|null> {
     const controller = new AbortController();
     this.fetches.add(controller);
     try {
@@ -74,8 +74,8 @@ class RepoPage extends BaseElement {
   }
 
   private async fetchUntriaged() {
-    const response = await this.cancelableFetch(
-        `/api/issues/untriaged/${this.owner}/${this.repo}`)
+    const response = await this.abortableFetch(
+        `/api/issues/untriaged/${this.owner}/${this.repo}`);
     if (!response) {
       return;
     }
@@ -84,7 +84,7 @@ class RepoPage extends BaseElement {
   }
 
   private async fetchLabels() {
-    const response = await this.cancelableFetch(
+    const response = await this.abortableFetch(
         `/api/issues/labels/${this.owner}/${this.repo}`);
     if (!response) {
       return;
@@ -94,7 +94,7 @@ class RepoPage extends BaseElement {
   }
 
   private async fetchFilteredIssues(labels: string[]) {
-    const response = await this.cancelableFetch(
+    const response = await this.abortableFetch(
         `/api/issues/by-labels/${this.owner}/${this.repo}/${labels.join(',')}`);
     if (!response) {
       return;

--- a/src/client/public/scripts/pages/repo.ts
+++ b/src/client/public/scripts/pages/repo.ts
@@ -15,6 +15,7 @@ class RepoPage extends BaseElement {
   @property() untriaged: api.Issue[] = [];
   @property() filteredIssues: api.Issue[] = [];
   @property() labels: api.Label[] = [];
+  private fetches: Set<AbortController> = new Set();
 
   private owner = '';
   private repo = '';
@@ -41,6 +42,9 @@ class RepoPage extends BaseElement {
     this.untriaged = [];
     this.labels = [];
     this.filteredIssues = [];
+    for (const controller of this.fetches.values()) {
+      controller.abort();
+    }
   }
 
   private updateFilter(id: FilterId, event: CustomEvent<FilterLegendEvent>) {
@@ -48,26 +52,53 @@ class RepoPage extends BaseElement {
     this.requestRender();
   }
 
+  /**
+   * This wraps fetch to keep track of pending fetches so they can be aborted if
+   * necessary.
+   */
+  private async cancelableFetch(input: RequestInfo): Promise<Response|null> {
+    const controller = new AbortController();
+    this.fetches.add(controller);
+    try {
+      const response = await fetch(input, {
+        credentials: 'include',
+        signal: controller.signal,
+      });
+
+      return response;
+    } catch {
+      return null;
+    } finally {
+      this.fetches.delete(controller);
+    }
+  }
+
   private async fetchUntriaged() {
-    const response = await fetch(
-        `/api/issues/untriaged/${this.owner}/${this.repo}`,
-        {credentials: 'include'});
+    const response = await this.cancelableFetch(
+        `/api/issues/untriaged/${this.owner}/${this.repo}`)
+    if (!response) {
+      return;
+    }
     const data = (await response.json()).data as api.IssuesResponse;
     this.untriaged = data.issues;
   }
 
   private async fetchLabels() {
-    const response = await fetch(
-        `/api/issues/labels/${this.owner}/${this.repo}`,
-        {credentials: 'include'});
+    const response = await this.cancelableFetch(
+        `/api/issues/labels/${this.owner}/${this.repo}`);
+    if (!response) {
+      return;
+    }
     const data = (await response.json()).data as api.LabelsResponse;
     this.labels = data.labels;
   }
 
   private async fetchFilteredIssues(labels: string[]) {
-    const response = await fetch(
-        `/api/issues/by-labels/${this.owner}/${this.repo}/${labels.join(',')}`,
-        {credentials: 'include'});
+    const response = await this.cancelableFetch(
+        `/api/issues/by-labels/${this.owner}/${this.repo}/${labels.join(',')}`);
+    if (!response) {
+      return;
+    }
     const data = (await response.json()).data as api.IssuesResponse;
     this.filteredIssues = data.issues;
   }


### PR DESCRIPTION
When switching between repo pages quickly, multiple network requests are sent and you can end up with the wrong data displayed since there's a race condition. This change aborts in flight fetches when switching between repo pages.