### PR TITLE
Better report # of new commits since last review

### DIFF
--- a/replays/[pixel-test]-project-health1-dashboard-UI/IncomingPullRequests-be58726dcbec2c1ac5f47c51da959cda535ef093
+++ b/replays/[pixel-test]-project-health1-dashboard-UI/IncomingPullRequests-be58726dcbec2c1ac5f47c51da959cda535ef093
@@ -83,6 +83,7 @@
                   "additions": 3,
                   "deletions": 1,
                   "changedFiles": 1,
+                  "authoredDate": "2018-03-12T19:09:21Z",
                   "pushedDate": "2018-03-12T19:09:22Z",
                   "oid": "14b676f9d5063c90e929871911a8d942d6a687bf",
                   "__typename": "Commit"
@@ -146,6 +147,7 @@
                   "additions": 3,
                   "deletions": 1,
                   "changedFiles": 1,
+                  "authoredDate": "2018-03-07T23:59:35Z",
                   "pushedDate": "2018-03-07T23:59:36Z",
                   "oid": "6b48b7f4a73de3bd5e6f91541941eaec816f2990",
                   "__typename": "Commit"
@@ -157,6 +159,7 @@
                   "additions": 1,
                   "deletions": 1,
                   "changedFiles": 1,
+                  "authoredDate": "2018-03-08T00:20:15Z",
                   "pushedDate": "2018-03-08T00:20:16Z",
                   "oid": "6879c9013521c45431a7ac42bf38374510cf5fce",
                   "__typename": "Commit"
@@ -229,6 +232,7 @@
                   "additions": 3,
                   "deletions": 1,
                   "changedFiles": 1,
+                  "authoredDate": "2018-02-07T22:25:07Z",
                   "pushedDate": "2018-02-07T22:25:08Z",
                   "oid": "f38c8afea9a6a8c8e47772cbd87e8839983aa140",
                   "__typename": "Commit"
@@ -292,6 +296,7 @@
                   "additions": 3,
                   "deletions": 1,
                   "changedFiles": 1,
+                  "authoredDate": "2018-02-07T19:24:17Z",
                   "pushedDate": "2018-02-07T19:24:18Z",
                   "oid": "f018b948f2906453a06c95089a785ba657eb0817",
                   "__typename": "Commit"
@@ -355,6 +360,7 @@
                   "additions": 3,
                   "deletions": 1,
                   "changedFiles": 1,
+                  "authoredDate": "2018-01-31T19:18:43Z",
                   "pushedDate": "2018-01-31T19:18:44Z",
                   "oid": "4eb760bbbeb1e9b5ee51010050fca4d1f2fe5dbb",
                   "__typename": "Commit"
@@ -366,6 +372,7 @@
                   "additions": 1,
                   "deletions": 1,
                   "changedFiles": 1,
+                  "authoredDate": "2018-01-31T19:19:59Z",
                   "pushedDate": "2018-01-31T19:20:01Z",
                   "oid": "bf67264ad3d77fcd9ad43cfcc13c8578fb9f57de",
                   "__typename": "Commit"
@@ -429,6 +436,7 @@
                   "additions": 3,
                   "deletions": 1,
                   "changedFiles": 1,
+                  "authoredDate": "2018-01-23T23:35:17Z",
                   "pushedDate": "2018-01-23T23:35:18Z",
                   "oid": "9b09af13ea76c068b99dfd81f457e76ca92d0299",
                   "__typename": "Commit"
@@ -625,8 +633,8 @@
     "rateLimit": {
       "cost": 1,
       "limit": 5000,
-      "remaining": 4990,
-      "resetAt": "2018-04-21T03:54:05Z",
+      "remaining": 4988,
+      "resetAt": "2018-04-30T18:21:32Z",
       "nodeCount": 3080,
       "__typename": "RateLimit"
     }

--- a/replays/[pixel-test]-project-health1-dashboard-UI/OutgoingPullRequests-be58726dcbec2c1ac5f47c51da959cda535ef093
+++ b/replays/[pixel-test]-project-health1-dashboard-UI/OutgoingPullRequests-be58726dcbec2c1ac5f47c51da959cda535ef093
@@ -705,8 +705,8 @@
     "rateLimit": {
       "cost": 1,
       "limit": 5000,
-      "remaining": 4990,
-      "resetAt": "2018-04-21T03:54:05Z",
+      "remaining": 4989,
+      "resetAt": "2018-04-30T18:21:32Z",
       "nodeCount": 150,
       "__typename": "RateLimit"
     }

--- a/replays/project-health1-dashboard-incoming/IncomingPullRequests-be58726dcbec2c1ac5f47c51da959cda535ef093
+++ b/replays/project-health1-dashboard-incoming/IncomingPullRequests-be58726dcbec2c1ac5f47c51da959cda535ef093
@@ -83,6 +83,7 @@
                   "additions": 3,
                   "deletions": 1,
                   "changedFiles": 1,
+                  "authoredDate": "2018-03-12T19:09:21Z",
                   "pushedDate": "2018-03-12T19:09:22Z",
                   "oid": "14b676f9d5063c90e929871911a8d942d6a687bf",
                   "__typename": "Commit"
@@ -146,6 +147,7 @@
                   "additions": 3,
                   "deletions": 1,
                   "changedFiles": 1,
+                  "authoredDate": "2018-03-07T23:59:35Z",
                   "pushedDate": "2018-03-07T23:59:36Z",
                   "oid": "6b48b7f4a73de3bd5e6f91541941eaec816f2990",
                   "__typename": "Commit"
@@ -157,6 +159,7 @@
                   "additions": 1,
                   "deletions": 1,
                   "changedFiles": 1,
+                  "authoredDate": "2018-03-08T00:20:15Z",
                   "pushedDate": "2018-03-08T00:20:16Z",
                   "oid": "6879c9013521c45431a7ac42bf38374510cf5fce",
                   "__typename": "Commit"
@@ -229,6 +232,7 @@
                   "additions": 3,
                   "deletions": 1,
                   "changedFiles": 1,
+                  "authoredDate": "2018-02-07T22:25:07Z",
                   "pushedDate": "2018-02-07T22:25:08Z",
                   "oid": "f38c8afea9a6a8c8e47772cbd87e8839983aa140",
                   "__typename": "Commit"
@@ -292,6 +296,7 @@
                   "additions": 3,
                   "deletions": 1,
                   "changedFiles": 1,
+                  "authoredDate": "2018-02-07T19:24:17Z",
                   "pushedDate": "2018-02-07T19:24:18Z",
                   "oid": "f018b948f2906453a06c95089a785ba657eb0817",
                   "__typename": "Commit"
@@ -355,6 +360,7 @@
                   "additions": 3,
                   "deletions": 1,
                   "changedFiles": 1,
+                  "authoredDate": "2018-01-31T19:18:43Z",
                   "pushedDate": "2018-01-31T19:18:44Z",
                   "oid": "4eb760bbbeb1e9b5ee51010050fca4d1f2fe5dbb",
                   "__typename": "Commit"
@@ -366,6 +372,7 @@
                   "additions": 1,
                   "deletions": 1,
                   "changedFiles": 1,
+                  "authoredDate": "2018-01-31T19:19:59Z",
                   "pushedDate": "2018-01-31T19:20:01Z",
                   "oid": "bf67264ad3d77fcd9ad43cfcc13c8578fb9f57de",
                   "__typename": "Commit"
@@ -429,6 +436,7 @@
                   "additions": 3,
                   "deletions": 1,
                   "changedFiles": 1,
+                  "authoredDate": "2018-01-23T23:35:17Z",
                   "pushedDate": "2018-01-23T23:35:18Z",
                   "oid": "9b09af13ea76c068b99dfd81f457e76ca92d0299",
                   "__typename": "Commit"
@@ -626,7 +634,7 @@
       "cost": 1,
       "limit": 5000,
       "remaining": 4999,
-      "resetAt": "2018-04-10T20:23:45Z",
+      "resetAt": "2018-04-30T18:21:31Z",
       "nodeCount": 3080,
       "__typename": "RateLimit"
     }

--- a/src/server/apis/dash-data.ts
+++ b/src/server/apis/dash-data.ts
@@ -205,6 +205,7 @@ query IncomingPullRequests($login: String!, $reviewRequestsQueryString: String!,
               additions
               deletions
               changedFiles
+              authoredDate
               pushedDate
               oid
             }

--- a/src/server/apis/dash-data/handle-incoming-pr-request.ts
+++ b/src/server/apis/dash-data/handle-incoming-pr-request.ts
@@ -132,18 +132,18 @@ export async function handleIncomingPRRequest(
       let lastPushedAt = 0;
       let lastOid;
       for (const node of pr.commits.nodes) {
-        if (!myReview || !node || !node.commit.pushedDate) {
+        if (!myReview || !node || !node.commit.authoredDate) {
           continue;
         }
-        const pushedAt = Date.parse(node.commit.pushedDate);
-        if (pushedAt <= myReview.createdAt) {
+        const authoredDate = Date.parse(node.commit.authoredDate);
+        if (authoredDate <= myReview.createdAt) {
           continue;
         }
         additions += node.commit.additions;
         deletions += node.commit.deletions;
         changedFiles += node.commit.changedFiles;
-        if (pushedAt > lastPushedAt) {
-          lastPushedAt = Date.parse(node.commit.pushedDate);
+        if (authoredDate > lastPushedAt) {
+          lastPushedAt = Date.parse(node.commit.authoredDate);
           lastOid = node.commit.oid;
         }
         newCommits.push(node);

--- a/src/test/server/apis/incoming-prs-test.ts
+++ b/src/test/server/apis/incoming-prs-test.ts
@@ -231,7 +231,7 @@ test('[incoming-prs-test]: Incoming PR that I reviewed. New commit since', (t) =
         additions: 1,
         deletions: 1,
         changedFiles: 1,
-        lastPushedAt: 1517426401000,
+        lastPushedAt: 1517426399000,
         url:
             'https://github.com/project-health1/repo/pull/9/files/4eb760bbbeb1e9b5ee51010050fca4d1f2fe5dbb..bf67264ad3d77fcd9ad43cfcc13c8578fb9f57de',
       }
@@ -315,7 +315,7 @@ test('[incoming-prs-test]: incoming with mention, new commits', (t) => {
         changedFiles: 1,
         count: 1,
         deletions: 1,
-        lastPushedAt: 1520468416000,
+        lastPushedAt: 1520468415000,
         type: 'NewCommitsEvent',
         url:
             'https://github.com/project-health1/repo/pull/13/files/6b48b7f4a73de3bd5e6f91541941eaec816f2990..6879c9013521c45431a7ac42bf38374510cf5fce',

--- a/src/types/gql-types.ts
+++ b/src/types/gql-types.ts
@@ -656,6 +656,8 @@ export interface IncomingPullRequestsQuery {
               deletions: number,
               // The number of changed files in this commit.
               changedFiles: number,
+              // The datetime when this commit was authored.
+              authoredDate: string,
               // The datetime when this commit was pushed.
               pushedDate: string | null,
               // The Git object ID


### PR DESCRIPTION
In some cases, you can author a series of commits and push the set of changes once. This will result in the dashboard reporting the incorrect number of commits: `1 new commit` instead of `4 new commits` since previously only `pushedDate` was used.