### PR TITLE
Fix installation webhook handling

### DIFF
--- a/src/server/controllers/github-app-webhooks.ts
+++ b/src/server/controllers/github-app-webhooks.ts
@@ -1,4 +1,8 @@
+import * as fse from 'fs-extra';
+import * as path from 'path';
+
 import * as webhooks from '../../types/webhooks';
+
 import {NotificationsSent} from './notifications';
 
 export interface WebhookListenerResponse {
@@ -14,6 +18,23 @@ export interface WebhookListener {
 export class WebhooksController {
   private eventsToListener =
       new Map<webhooks.WebhookType, Set<WebhookListener>>();
+
+  constructor() {
+    this.loadControllers('webhook-handlers');
+    this.loadControllers('webhook-handlers/notifications');
+    this.loadControllers('webhook-handlers/updaters');
+  }
+
+  private loadControllers(dir: string) {
+    const dirPath = path.join(__dirname, dir);
+    const files = fse.readdirSync(dirPath);
+    for (const file of files) {
+      if (path.extname(file) === '.js') {
+        console.log(`loading ${dirPath}/${file}`);
+import(path.join(dirPath, file));
+      }
+    }
+  }
 
   /**
    * Subscribes the listener to the specified events.

--- a/src/server/controllers/github-app-webhooks.ts
+++ b/src/server/controllers/github-app-webhooks.ts
@@ -30,7 +30,6 @@ export class WebhooksController {
     const files = fse.readdirSync(dirPath);
     for (const file of files) {
       if (path.extname(file) === '.js') {
-        console.log(`loading ${dirPath}/${file}`);
 import(path.join(dirPath, file));
       }
     }

--- a/src/test/server/controllers/webhook-events/github-app-install-test.ts
+++ b/src/test/server/controllers/webhook-events/github-app-install-test.ts
@@ -71,7 +71,7 @@ function newFakeRepositoriesPayload():
     }],
     repositories_removed: [{
       id: 456,
-      name: 'test-repo2',
+      name: 'test-repo',
       full_name: 'test-owner/test-repo',
       private: false,
     }],
@@ -209,16 +209,14 @@ test.serial('[handleGithubAppInstall]: handles add then update', async (t) => {
   const githubInstance = github();
   const queryStub = t.context.sandbox.stub(githubInstance, 'query');
 
-  function createQueryResponse(id: string) {
-    return {data: {repository: {id}}};
+  function createQueryResponse(id: string, name: string) {
+    return {data: {repository: {id, name}}};
   }
 
   queryStub.onFirstCall()
-      .returns(createQueryResponse('test-repo-id'))
+      .returns(createQueryResponse('test-repo-id', 'test-repo'))
       .onSecondCall()
-      .returns(createQueryResponse('new-repo-id'))
-      .onThirdCall()
-      .returns(createQueryResponse('test-repo-id'));
+      .returns(createQueryResponse('new-repo-id', 'new-repo'));
 
   const response = await appInstaller.handleWebhookEvent(newFakeHookDetails());
   t.not(response, null, 'Payload is handled');


### PR DESCRIPTION
This change fixes two issues:
 - Webhook handlers which self register themselves were not being correctly loaded.
 - Repo deletion generated a query for repositories that the installation requested removal. As a result, GitHub does not permit access to these repositories. This change removes queries to GitHub for removed repositories.